### PR TITLE
Add curl in the package install

### DIFF
--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -5,7 +5,7 @@ ENV VERSION %%VERSION%%
 ENV LANG C.UTF-8
 
 # Setup base
-RUN apk add --no-cache jq git python
+RUN apk add --no-cache jq git python curl
 
 # Copy data
 COPY run.sh /

--- a/letsencrypt/config.json
+++ b/letsencrypt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Let's Encrypt",
-  "version": "0.3",
+  "version": "0.4",
   "slug": "letsencrypt",
   "description": "Manage Let's Encrypt certificate",
   "url": "https://home-assistant.io/addons/lets_encrypt/",


### PR DESCRIPTION
The run.sh requires curl which appears to be missing the container.