### PR TITLE
Update DuckDNS plugin to also update IPv6

### DIFF
--- a/duckdns/Dockerfile
+++ b/duckdns/Dockerfile
@@ -4,7 +4,7 @@ FROM %%BASE_IMAGE%%
 ENV LANG C.UTF-8
 
 # Setup base
-RUN apk add --no-cache jq curl
+RUN apk add --no-cache jq curl dig
 
 # Copy data
 COPY run.sh /

--- a/duckdns/run.sh
+++ b/duckdns/run.sh
@@ -7,9 +7,12 @@ TOKEN=$(jq --raw-output '.token' $CONFIG_PATH)
 DOMAINS=$(jq --raw-output '.domains | join(",")' $CONFIG_PATH)
 WAIT_TIME=$(jq --raw-output '.seconds' $CONFIG_PATH)
 
+IP_V4=${dig +short myip.opendns.com @resolver1.opendns.com}
+IP_V6=${dig +short -6 myip.opendns.com aaaa @resolver1.ipv6-sandbox.opendns.com}
+
 # Run duckdns
 while true; do
-    ANSWER="$(curl -sk "https://www.duckdns.org/update?domains=$DOMAINS&token=$TOKEN&ip=&verbose=true")" || true
+    ANSWER="$(curl -sk "https://www.duckdns.org/update?domains=$DOMAINS&token=$TOKEN&ip=$IP_V4&ipv6=IP_V6&verbose=true")" || true
     echo "$(date): $ANSWER"
     sleep "$WAIT_TIME"
 done

--- a/duckdns/run.sh
+++ b/duckdns/run.sh
@@ -7,8 +7,8 @@ TOKEN=$(jq --raw-output '.token' $CONFIG_PATH)
 DOMAINS=$(jq --raw-output '.domains | join(",")' $CONFIG_PATH)
 WAIT_TIME=$(jq --raw-output '.seconds' $CONFIG_PATH)
 
-IP_V4=${dig +short myip.opendns.com @resolver1.opendns.com}
-IP_V6=${dig +short -6 myip.opendns.com aaaa @resolver1.ipv6-sandbox.opendns.com}
+IP_V4=$(dig +short myip.opendns.com @resolver1.opendns.com | grep -v "connection timed out")
+IP_V6=$(dig +short -6 myip.opendns.com aaaa @resolver1.ipv6-sandbox.opendns.com | grep -v "connection timed out")
 
 # Run duckdns
 while true; do


### PR DESCRIPTION
This doesn't work properly yet, I was struggling to get `dig` added to the as a package in the Dockerfile. It needs to come from a custom repo which looks like is platform dependent (https://pkgs.alpinelinux.org/contents?file=dig).

Pull requesting now as I don't know when I'll get chance to finish figuring this out and it might be a simple fix for someone a bit more familiar with the Docker.