### PR TITLE
Reject conntions not using correct hostname

### DIFF
--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "NGINX Home Assistant SSL proxy",
-  "version": "0.5",
+  "version": "0.6",
   "slug": "nginx_proxy",
   "description": "An SSL/TLS proxy",
   "url": "https://home-assistant.io/addons/nginx_proxy/",

--- a/nginx_proxy/nginx.conf
+++ b/nginx_proxy/nginx.conf
@@ -44,7 +44,7 @@ http {
         proxy_buffering off;
 
         location / {
-            proxy_pass http://172.17.0.1:8123;
+            proxy_pass http://homeassistant:8123;
             proxy_set_header Host $host;
             proxy_redirect http:// https://;
             proxy_http_version 1.1;

--- a/nginx_proxy/nginx.conf
+++ b/nginx_proxy/nginx.conf
@@ -13,6 +13,10 @@ http {
     }
 
     server {
+        return 444;
+    }
+
+    server {
         server_name %%DOMAIN%%;
 
         # These shouldn't need to be changed


### PR DESCRIPTION
This PR adds a _wildcard_ server-configuration which resets HTTP requests not including the correct hostname (`server_name`). Generic attacks to the IP address could be reduced a bit this way. Not filtering out requests this way would lead nginx to serve the forwarded content regardless of the used hostname.

Can we expect users to always use the hostname they have configured the addon with to access their HASS? This would break setups where people just use some self-signed certificate and connect via a hostname that does not match the configured domain-option for the addon. Which would kind of defeat the purppose of setting the hostname in the first place, but who knows.