### PR TITLE
Change redirection method for incorrect hostname

### DIFF
--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "NGINX Home Assistant SSL proxy",
-  "version": "0.6",
+  "version": "0.7",
   "slug": "nginx_proxy",
   "description": "An SSL/TLS proxy",
   "url": "https://home-assistant.io/addons/nginx_proxy/",

--- a/nginx_proxy/nginx.conf
+++ b/nginx_proxy/nginx.conf
@@ -13,6 +13,11 @@ http {
     }
 
     server {
+        server_name _;
+        listen [::]:80 default_server ipv6only=off;
+        listen [::]:443 ssl http2 default_server ipv6only=off;
+        ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
+        ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
         return 444;
     }
 
@@ -20,7 +25,7 @@ http {
         server_name %%DOMAIN%%;
 
         # These shouldn't need to be changed
-        listen [::]:80 default_server ipv6only=off;
+        listen [::]:80;
         return 301 https://$host$request_uri;
     }
 
@@ -33,7 +38,7 @@ http {
         # dhparams file
         ssl_dhparam /data/dhparams.pem;
 
-        listen [::]:443 http2 default_server ipv6only=off;
+        listen [::]:443 http2;
         add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
         ssl on;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;

--- a/nginx_proxy/nginx.conf
+++ b/nginx_proxy/nginx.conf
@@ -16,8 +16,8 @@ http {
         server_name _;
         listen [::]:80 default_server ipv6only=off;
         listen [::]:443 ssl http2 default_server ipv6only=off;
-        ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
-        ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
+        ssl_certificate /data/ssl-cert-snakeoil.pem;
+        ssl_certificate_key /data/ssl-cert-snakeoil.key;
         return 444;
     }
 

--- a/nginx_proxy/run.sh
+++ b/nginx_proxy/run.sh
@@ -4,15 +4,24 @@ set -e
 CONFIG_PATH=/data/options.json
 DHPARAMS_PATH=/data/dhparams.pem
 
+SNAKEOIL_CERT=/etc/ssl/certs/ssl-cert-snakeoil.pem
+SNAKEOIL_KEY=/etc/ssl/private/ssl-cert-snakeoil.key
+
 DOMAIN=$(jq --raw-output ".domain" $CONFIG_PATH)
 KEYFILE=$(jq --raw-output ".keyfile" $CONFIG_PATH)
 CERTFILE=$(jq --raw-output ".certfile" $CONFIG_PATH)
-
 
 # Generate dhparams
 if [ ! -f "$DHPARAMS_PATH" ]; then
     echo "[INFO] Generate dhparams..."
     openssl dhparam -dsaparam -out "$DHPARAMS_PATH" 4096 > /dev/null
+fi
+
+if [ ! -f "$SNAKEOIL_CERT" ]; then
+    echo "[INFO] Create snakeoil (self-signed certificate)"
+    mkdir -p "$(dirname $SNAKEOIL_CERT)"
+    mkdir -p "$(dirname $SNAKEOIL_KEY)"
+    openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout $SNAKEOIL_KEY -out $SNAKEOIL_CERT -subj '/CN=localhost'
 fi
 
 # Prepare config file

--- a/nginx_proxy/run.sh
+++ b/nginx_proxy/run.sh
@@ -4,8 +4,8 @@ set -e
 CONFIG_PATH=/data/options.json
 DHPARAMS_PATH=/data/dhparams.pem
 
-SNAKEOIL_CERT=/etc/ssl/certs/ssl-cert-snakeoil.pem
-SNAKEOIL_KEY=/etc/ssl/private/ssl-cert-snakeoil.key
+SNAKEOIL_CERT=/data/ssl-cert-snakeoil.pem
+SNAKEOIL_KEY=/data/ssl-cert-snakeoil.key
 
 DOMAIN=$(jq --raw-output ".domain" $CONFIG_PATH)
 KEYFILE=$(jq --raw-output ".keyfile" $CONFIG_PATH)
@@ -19,8 +19,6 @@ fi
 
 if [ ! -f "$SNAKEOIL_CERT" ]; then
     echo "[INFO] Create snakeoil (self-signed certificate)"
-    mkdir -p "$(dirname $SNAKEOIL_CERT)"
-    mkdir -p "$(dirname $SNAKEOIL_KEY)"
     openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout $SNAKEOIL_KEY -out $SNAKEOIL_CERT -subj '/CN=localhost'
 fi
 


### PR DESCRIPTION
Attempt to fix https://github.com/home-assistant/home-assistant/issues/9265 which was preventing nginx server to start on my pi3 running hass.io