### PR TITLE
Updated Snips to newest version (v0.5.5).

### DIFF
--- a/snips/config.json
+++ b/snips/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Snips.AI",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "slug": "snips",
   "description": "Local voice control platform",
   "url": "https://home-assistant.io/addons/snips/",


### PR DESCRIPTION
v0.5.5 changelog:
- fix the bug that crashes the `snips-audio-server` after succesfully playing few audio samples