### PR TITLE
Adding support for deployment_key for git_pull addon

### DIFF
--- a/git_pull/Dockerfile
+++ b/git_pull/Dockerfile
@@ -5,7 +5,7 @@ FROM $BUILD_FROM
 ENV LANG C.UTF-8
 
 # Setup base
-RUN apk add --no-cache jq curl git openssh
+RUN apk add --no-cache jq curl git openssh-client
 
 # Copy data
 COPY run.sh /

--- a/git_pull/Dockerfile
+++ b/git_pull/Dockerfile
@@ -5,7 +5,7 @@ FROM $BUILD_FROM
 ENV LANG C.UTF-8
 
 # Setup base
-RUN apk add --no-cache jq curl git
+RUN apk add --no-cache jq curl git openssh
 
 # Copy data
 COPY run.sh /

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "1.1",
+  "version": "2.0",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -9,6 +9,8 @@
   "hassio_api": true,
   "map": ["config:rw"],
   "options": {
+    "deployment_key": [],
+    "deployment_key_protocol": "rsa",
     "repository": null,
     "auto_restart": false,
     "repeat": {
@@ -17,6 +19,8 @@
     }
   },
   "schema": {
+    "deployment_key": ["str"],
+    "deployment_key_protocol": "str",
     "repository": "url",
     "auto_restart": "bool",
     "repeat": {

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -20,7 +20,7 @@
   },
   "schema": {
     "deployment_key": ["str"],
-    "deployment_key_protocol": "str",
+    "deployment_key_protocol": "match(rsa|dsa|ecdsa|ed25519|rsa)",
     "repository": "url",
     "auto_restart": "bool",
     "repeat": {

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -3,10 +3,25 @@ set -e
 
 CONFIG_PATH=/data/options.json
 
+DEPLOYMENT_KEY=$(jq --raw-output ".deployment_key[]" $CONFIG_PATH)
+DEPLOYMENT_KEY_PROTOCOL=$(jq --raw-output ".deployment_key_protocol" $CONFIG_PATH)
 REPOSITORY=$(jq --raw-output '.repository' $CONFIG_PATH)
 AUTO_RESTART=$(jq --raw-output '.auto_restart' $CONFIG_PATH)
 REPEAT_ACTIVE=$(jq --raw-output '.repeat.active' $CONFIG_PATH)
 REPEAT_INTERVAL=$(jq --raw-output '.repeat.interval' $CONFIG_PATH)
+
+# prepare the private key, if provided
+if [ ! -z "$DEPLOYMENT_KEY" ]; then
+    echo "[Info] setup deployment_key on id_$DEPLOYMENT_KEY_PROTOCOL"
+
+    mkdir -p ~/.ssh
+    while read -r line; do
+        echo "$line" >> ~/.ssh/id_$DEPLOYMENT_KEY_PROTOCOL
+    done <<< "$DEPLOYMENT_KEY"
+
+    chmod 600 ~/.ssh/id_$DEPLOYMENT_KEY_PROTOCOL
+fi
+
 
 # init config repositorie
 if [ ! -d /config/.git ]; then

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -12,14 +12,14 @@ REPEAT_INTERVAL=$(jq --raw-output '.repeat.interval' $CONFIG_PATH)
 
 # prepare the private key, if provided
 if [ ! -z "$DEPLOYMENT_KEY" ]; then
-    echo "[Info] setup deployment_key on id_$DEPLOYMENT_KEY_PROTOCOL"
+    echo "[Info] setup deployment_key on id_${DEPLOYMENT_KEY_PROTOCOL}"
 
     mkdir -p ~/.ssh
     while read -r line; do
-        echo "$line" >> ~/.ssh/id_$DEPLOYMENT_KEY_PROTOCOL
+        echo "$line" >> "~/.ssh/id_${DEPLOYMENT_KEY_PROTOCOL}"
     done <<< "$DEPLOYMENT_KEY"
 
-    chmod 600 ~/.ssh/id_$DEPLOYMENT_KEY_PROTOCOL
+    chmod 600 "~/.ssh/id_${DEPLOYMENT_KEY_PROTOCOL}"
 fi
 
 

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -16,10 +16,10 @@ if [ ! -z "$DEPLOYMENT_KEY" ]; then
 
     mkdir -p ~/.ssh
     while read -r line; do
-        echo "$line" >> "~/.ssh/id_${DEPLOYMENT_KEY_PROTOCOL}"
+        echo "$line" >> "${HOME}/.ssh/id_${DEPLOYMENT_KEY_PROTOCOL}"
     done <<< "$DEPLOYMENT_KEY"
 
-    chmod 600 "~/.ssh/id_${DEPLOYMENT_KEY_PROTOCOL}"
+    chmod 600 "${HOME}/.ssh/id_${DEPLOYMENT_KEY_PROTOCOL}"
 fi
 
 


### PR DESCRIPTION
The main idea is to allow the user to provide a private key which will be used typically as "deployment_key".

The json will be something like:

```json
{ (...)
  "deployment_key": [
"-----BEGIN RSA PRIVATE KEY-----",
"MIIEpAIBAAKCAQEArNTRDaU1nQ/Fcb5VttyxTuEEpf+W3tNe6QMVswAXAirDh4Do",
"WTC1/IFae89jId5FckmFOszskAqoCLjI6ZrnxP3ZLW7yVsDn7TkI0iR21DdJ/fSU",
(...)
"-----END RSA PRIVATE KEY-----"
],
  "deployment_key_protocol": "rsa"
}
```

The multiline is a bit messy, but seems the more comfortable way to make copy&paste. The alternative is to add `\n` for each line and remove the lines and the json becomes unreadable.

Note that `deployment_key_protocol` is optional and defaults to `rsa`. The idea is to allow the user to allow any of the typically supported ssh protocols for identities, which are:

  * `dsa`
  * `ecdsa`
  * `ed25519`
  * `rsa`

I don't consider the `~/.ssh/identity`, which appears in the man pages, but I have never seen it nowadays. I assume most people will do `ssh-keygen` and just forget about the protocol (`rsa` seems to be the default in all the `ssh` packages I have ever used). All the aforementioned protocols are suffix to `~/.ssh/id_<suffix>` so that is simply used as the file name.

If this PR sounds good, I am ready to add the documentation for it.