### PR TITLE
Use jq as a tool to validate all JSON files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ addons:
     - debian-sid    # Grab shellcheck from the Debian repo (o_O)
     packages:
     - shellcheck
+    - jq
 
 script:
  - bash -c 'shopt -s globstar; shellcheck **/*.sh'
+ - bash -c 'shopt -s globstar ; jq . **/*.json'
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
In this PR I have added a check to validate JSON. It seems nice to have it, just in case. The behaviour of `xargs` for doing this test seemed correct in my tests. I ended up using it because `jsonlint-php` doesn't behave well with multiple files as parameters, and it was the easiest package to add given that it is in the repositories.