### PR TITLE
Use reflog to calculate diff and allow 'git://' repo addresses

### DIFF
--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "2.0",
+  "version": "2.1",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",
@@ -21,7 +21,7 @@
   "schema": {
     "deployment_key": ["str"],
     "deployment_key_protocol": "match(rsa|dsa|ecdsa|ed25519|rsa)",
-    "repository": "match((?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\.git)(\/?|\#[-\d\w._]+?))",
+    "repository": "match((?:git|ssh|https?|git@[-\\w.]+):(\/\/)?(.*?)(\\.git)(\/?|\\#[-\\d\\w._]+?))",
     "auto_restart": "bool",
     "repeat": {
       "active": "bool",

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -21,7 +21,7 @@
   "schema": {
     "deployment_key": ["str"],
     "deployment_key_protocol": "match(rsa|dsa|ecdsa|ed25519|rsa)",
-    "repository": "url",
+    "repository": "str",
     "auto_restart": "bool",
     "repeat": {
       "active": "bool",

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -21,7 +21,7 @@
   "schema": {
     "deployment_key": ["str"],
     "deployment_key_protocol": "match(rsa|dsa|ecdsa|ed25519|rsa)",
-    "repository": "str",
+    "repository": "match((?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\.git)(\/?|\#[-\d\w._]+?))",
     "auto_restart": "bool",
     "repeat": {
       "active": "bool",

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -43,7 +43,7 @@ while true; do
 
     # Enable autorestart of homeassistant
     if [ "$AUTO_RESTART" == "true" ]; then
-        changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+        changed_files="$(git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD)"
 
         # Files have changed & check config
         if [ ! -z "$changed_files" ]; then

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -43,7 +43,7 @@ while true; do
 
     # Enable autorestart of homeassistant
     if [ "$AUTO_RESTART" == "true" ]; then
-        changed_files="$(git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD)"
+        changed_files="$(git diff-tree -r --name-only --no-commit-id 'HEAD@{1}' HEAD)"
 
         # Files have changed & check config
         if [ ! -z "$changed_files" ]; then


### PR DESCRIPTION
Some people prefer to use ssh addressing for their repo instead of https addressing. Changing the config restriction from `url` to `str` would allow them to do this.

For the reflog change to calculate changed files please refer to this answer from https://stackoverflow.com/questions/964876/head-and-orig-head-in-git

> HEAD is (direct or indirect, i.e. symbolic) reference to the current commit. It is a commit that you have checked in the working directory (unless you made some changes, or equivalent), and it is a commit on top of which "git commit" would make a new one. Usually HEAD is symbolic reference to some other named branch; this branch is currently checked out branch, or current branch. HEAD can also point directly to a commit; this state is called "detached HEAD", and can be understood as being on unnamed, anonymous branch.
> 
> And @ alone is a shortcut for HEAD, since Git 1.8.5
> 
> ORIG_HEAD is previous state of HEAD, set by commands that have possibly dangerous behavior, to be easy to revert them. It is less useful now that Git has reflog: HEAD@{1} is roughly equivalent to ORIG_HEAD (HEAD@{1} is always last value of HEAD, ORIG_HEAD is last value of HEAD before dangerous operation).
> 
> For more information read git(1) manpage, Git User's Manual, the Git Community Book and Git Glossary
