### PR TITLE
Added banlimit and dirsfirst options, fix broken API

### DIFF
--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Configurator",
-  "version": "0.2.0-p3",
+  "version": "0.2.3",
   "slug": "configurator",
   "description": "Browser-based configuration file editor for Home Assistant.",
   "url": "https://home-assistant.io/addons/configurator",
@@ -20,7 +20,9 @@
     "ssl": false,
     "allowed_networks": ["192.168.0.0/16"],
     "banned_ips": ["8.8.8.8"],
-    "ignore_pattern": ["__pycache__"]
+    "banlimit": 0,
+    "ignore_pattern": ["__pycache__"],
+    "dirsfirst": false
   },
   "schema": {
     "username": "str",
@@ -30,7 +32,9 @@
     "ssl": "bool",
     "allowed_networks": ["str"],
     "banned_ips": ["str"],
-    "ignore_pattern": ["str"]
+    "banlimit": "int",
+    "ignore_pattern": ["str"],
+    "dirsfirst": "bool"
   },
   "image": "homeassistant/{arch}-addon-configurator"
 }

--- a/configurator/map.py
+++ b/configurator/map.py
@@ -13,15 +13,17 @@ configurator = {
     'BASEPATH': "/config",
     'HASS_API': "http://hassio/homeassistant/api/",
     'HASS_API_PASSWORD': None,
-    'CREDENTIALS': 
+    'CREDENTIALS':
         "{}:{}".format(options['username'], options['password']),
-    'SSL_CERTIFICATE': 
+    'SSL_CERTIFICATE':
         "ssl/{}".format(options['certfile']) if options['ssl'] else None,
-    'SSL_KEY': 
+    'SSL_KEY':
         "ssl/{}".format(options['keyfile']) if options['ssl'] else None,
     'ALLOWED_NETWORKS': options['allowed_networks'],
     'BANNED_IPS': options['banned_ips'],
     'IGNORE_PATTERN': options['ignore_pattern'],
+    'BANLIMIT': options['banlimit'],
+    'DIRSFIRST': options['dirsfirst'],
 }
 
 with Path(sys.argv[1]).open('w') as json_file:


### PR DESCRIPTION
Jumping from 0.2.0 to 0.2.3 to get in sync with the official configurator.
Adding new options:
- `banlimit` (enable banning IPs after failed login attempts)
- `dirsfirst` (display directories first in filebrowser)

Additionally, the data that was being fetched from HASS' `bootstrap` API has been moved to the dedicated endpoints. Apparently `bootstrap` has been removed (https://github.com/home-assistant/home-assistant/issues/10404).

Will do the documentation shortly. This PR should be merged regardless to fix the API-issue. With the defaults of the new options the configurator behaves just like before. So people can leave it like that until they know what those options do.