### PR TITLE
Disable binlogging by default

### DIFF
--- a/mariadb/run.sh
+++ b/mariadb/run.sh
@@ -18,7 +18,7 @@ fi
 
 # Start mariadb
 echo "[INFO] Start MariaDB"
-mysqld_safe --datadir="$MARIADB_DATA" --user=root < /dev/null &
+mysqld_safe --datadir="$MARIADB_DATA" --user=root --max-binlog-size=268435456 --expire-logs-days=1 < /dev/null &
 MARIADB_PID=$!
 
 # Wait until DB is running

--- a/mariadb/run.sh
+++ b/mariadb/run.sh
@@ -18,7 +18,7 @@ fi
 
 # Start mariadb
 echo "[INFO] Start MariaDB"
-mysqld_safe --datadir="$MARIADB_DATA" --user=root --max-binlog-size=268435456 --expire-logs-days=1 < /dev/null &
+mysqld_safe --datadir="$MARIADB_DATA" --user=root --log-bin=0 < /dev/null &
 MARIADB_PID=$!
 
 # Wait until DB is running


### PR DESCRIPTION
The default configuration in mariadb will write binlogs without limit or rotation.  The binlogging will fill up the disk on small embedded devices and worse:  the constant writes are likely to severely shorten the usable lifespan of a SD card when running this on a raspberry pi.

For this application, you're unlikely to ever need the binlogging, since people running hassio aren't likely doing replay log backups or replication.  As such, I suggest it should be disabled by default.  If we feel that there may be users who want this, we could add a configuration option in to support it, but I would also suggest that such a use case isn't really the target of this addon.