### PR TITLE
Disable binlogging by default

### DIFF
--- a/mariadb/config.json
+++ b/mariadb/config.json
@@ -1,6 +1,6 @@
 {
   "name": "MariaDB",
-  "version": "0.1",
+  "version": "0.2",
   "slug": "mariadb",
   "description": "An SQL database server",
   "url": "https://home-assistant.io/addons/mariadb/",

--- a/mariadb/run.sh
+++ b/mariadb/run.sh
@@ -18,7 +18,7 @@ fi
 
 # Start mariadb
 echo "[INFO] Start MariaDB"
-mysqld_safe --datadir="$MARIADB_DATA" --user=root < /dev/null &
+mysqld_safe --datadir="$MARIADB_DATA" --user=root --max-binlog-size=268435456 --expire-logs-days=1 < /dev/null &
 MARIADB_PID=$!
 
 # Wait until DB is running

--- a/mariadb/run.sh
+++ b/mariadb/run.sh
@@ -18,7 +18,7 @@ fi
 
 # Start mariadb
 echo "[INFO] Start MariaDB"
-mysqld_safe --datadir="$MARIADB_DATA" --user=root --log-bin=0 < /dev/null &
+mysqld_safe --datadir="$MARIADB_DATA" --user=root --skip-log-bin < /dev/null &
 MARIADB_PID=$!
 
 # Wait until DB is running

--- a/mariadb/run.sh
+++ b/mariadb/run.sh
@@ -18,7 +18,7 @@ fi
 
 # Start mariadb
 echo "[INFO] Start MariaDB"
-mysqld_safe --datadir="$MARIADB_DATA" --user=root --max-binlog-size=268435456 --expire-logs-days=1 < /dev/null &
+mysqld_safe --datadir="$MARIADB_DATA" --user=root --log-bin=0 < /dev/null &
 MARIADB_PID=$!
 
 # Wait until DB is running


### PR DESCRIPTION
The default configuration in mariadb will write binlogs without limit or rotation. The binlogging will fill up the disk on small embedded devices and worse: the constant writes are likely to severely shorten the usable lifespan of a SD card when running this on a raspberry pi.

For this application, you're unlikely to ever need the binlogging, since people running hassio aren't likely doing replay log backups or replication.  The innodb transaction logs are separate and not affected by this conversation so the database is still replay-save in the event of a crash/power-loss event. As such, I suggest binlogs should be disabled by default. If we feel that there may be users who want this, we could add a configuration option in to support it, but I would also suggest that such a use case isn't really the target of this addon.