### PR TITLE
git_pull: Prevent plugin from always restarting hass.io even if nothing has changed

### DIFF
--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "2.1",
+  "version": "2.2",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -34,19 +34,24 @@ if [ ! -d /config/.git ]; then
     fi
 fi
 
-# Run duckdns
+# Main programm
 cd /config
 while true; do
 
+    # get actual commit id
     echo "[Info] pull from $REPOSITORY"
+    
+    # perform pull
     git pull 2&> /dev/null || true
+    
+    # get actual (new) commit id
+    NEW_COMMIT=$(git rev-parse HEAD)
 
     # Enable autorestart of homeassistant
     if [ "$AUTO_RESTART" == "true" ]; then
-        changed_files="$(git diff-tree -r --name-only --no-commit-id 'HEAD@{1}' HEAD)"
 
-        # Files have changed & check config
-        if [ ! -z "$changed_files" ]; then
+        # Compare commit ids & check config
+        if [ $NEW_COMMIT != $OLD_COMMIT ]; then
             echo "[Info] check Home-Assistant config"
             if api_ret="$(curl -s -X POST http://hassio/homeassistant/check)"; then
                 result="$(echo "$api_ret" | jq --raw-output ".result")"

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -39,16 +39,16 @@ cd /config
 while true; do
 
     # get actual commit id
-    echo "[Info] pull from $REPOSITORY"
+    OLD_COMMIT=$(git rev-parse HEAD)
     
     # perform pull
-    OLD_COMMIT=$(git rev-parse HEAD)
+    echo "[Info] pull from $REPOSITORY"
     git pull 2&> /dev/null || true
     
     # get actual (new) commit id
     NEW_COMMIT=$(git rev-parse HEAD)
 
-    # Enable autorestart of homeassistant
+    # autorestart of homeassistant if enabled
     if [ "$AUTO_RESTART" == "true" ]; then
 
         # Compare commit ids & check config
@@ -65,6 +65,8 @@ while true; do
                     echo "[Error] invalid config!"
                 fi
             fi
+        else
+            echo "[Info] Nothing has changed."
         fi
     fi
 

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -42,6 +42,7 @@ while true; do
     echo "[Info] pull from $REPOSITORY"
     
     # perform pull
+    OLD_COMMIT=$(git rev-parse HEAD)
     git pull 2&> /dev/null || true
     
     # get actual (new) commit id

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -52,7 +52,7 @@ while true; do
     if [ "$AUTO_RESTART" == "true" ]; then
 
         # Compare commit ids & check config
-        if [ $NEW_COMMIT != $OLD_COMMIT ]; then
+        if [ "$NEW_COMMIT" != "$OLD_COMMIT" ]; then
             echo "[Info] check Home-Assistant config"
             if api_ret="$(curl -s -X POST http://hassio/homeassistant/check)"; then
                 result="$(echo "$api_ret" | jq --raw-output ".result")"


### PR DESCRIPTION
By comparing commit ids rather than comparing HEAD with HEAD - 1 this prevents the plugin from always restarting hass.io