### PR TITLE
Fix bash variable input

### DIFF
--- a/tellstick/config.json
+++ b/tellstick/config.json
@@ -1,6 +1,6 @@
 {
   "name": "TellStick",
-  "version": "0.2",
+  "version": "0.3",
   "slug": "tellstick",
   "description": "TellStick and TellStick Duo service.",
   "url": "https://home-assistant.io/addons/tellstick/",

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -72,7 +72,7 @@ while read -r input; do
     input="$(echo "$input" | jq --raw-output '.')"
     echo "[Info] Read alias: $input"
 
-    if msg="$(tdtool --${input})"; then
+    if msg="$(tdtool "--$input")"; then
     	echo "[Error] TellStick Command output -> $msg"
     fi
 done

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -72,7 +72,9 @@ while read -r input; do
     input="$(echo "$input" | jq --raw-output '.')"
     echo "[Info] Read alias: $input"
 
-    if msg="$(tdtool "--$input")"; then
-    	echo "[Error] TellStick Command output -> $msg"
+    if ! msg="$(tdtool "--$input")"; then
+    	echo "[Error] TellStick Command fails -> $msg"
+    else
+        echo "[Info] TellStick Command success -> $msg"
     fi
 done

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -72,7 +72,7 @@ while read -r input; do
     input="$(echo "$input" | jq --raw-output '.')"
     echo "[Info] Read alias: $input"
 
-    if ! msg="$(tdtool --$input)"; then
-    	echo "[Error] TellStick Command failed -> $msg"
+    if msg="$(tdtool --${input})"; then
+    	echo "[Error] TellStick Command output -> $msg"
     fi
 done

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -72,7 +72,7 @@ while read -r input; do
     input="$(echo "$input" | jq --raw-output '.')"
     echo "[Info] Read alias: $input"
 
-    if ! msg="$(tdtool --"$input")"; then
+    if ! msg="$(tdtool --$input)"; then
     	echo "[Error] TellStick Command failed -> $msg"
     fi
 done

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -63,7 +63,7 @@ socat TCP-LISTEN:50800,reuseaddr,fork UNIX-CONNECT:/tmp/TelldusClient &
 socat TCP-LISTEN:50801,reuseaddr,fork UNIX-CONNECT:/tmp/TelldusEvents &
 
 # Run telldus-core daemon in the background
-exec /usr/local/sbin/telldusd --nodaemon < /dev/null &
+/usr/local/sbin/telldusd --nodaemon < /dev/null &
 
 # Listen for input to tdtool
 echo "[Info] Starting event listener"


### PR DESCRIPTION
This will cause error in validation however it actually works..

I have tried with different versions to this without success in the addon:
`if ! msg="$(tdtool --"$input")"; then`
`if ! msg="$(tdtool --"${input}")"; then`

It passes the data sent via addon_stdio but something is parsed wrong when it is executing the command and tdtool exits with invalid input error.

The only one i got working in real life is these two:
`if ! msg="$(tdtool --$input)"; then`
`if ! msg="$(tdtool --${input})"; then`
