### PR TITLE
Stdin does not work with quoting on $input

### DIFF
--- a/tellstick/config.json
+++ b/tellstick/config.json
@@ -1,6 +1,6 @@
 {
   "name": "TellStick",
-  "version": "0.3",
+  "version": "0.4",
   "slug": "tellstick",
   "description": "TellStick and TellStick Duo service.",
   "url": "https://home-assistant.io/addons/tellstick/",

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -72,9 +72,9 @@ while read -r input; do
     input="$(echo "$input" | jq --raw-output '.')"
     echo "[Info] Read alias: $input"
     
-    input=("tdtool --$input")
-    input_arr=()
-    for word in ${input[@]}; do
+    input=("--$input")
+    input_arr=("tdtool")
+    for word in $input; do
         input_arr+=("$word")
     done
 	

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -72,11 +72,12 @@ while read -r input; do
     input="$(echo "$input" | jq --raw-output '.')"
     echo "[Info] Read alias: $input"
     
-    input_arr=()
+    input=("--$input")
+    input_arr=("tdtool")
     for word in $input; do
         input_arr+=("$word")
     done
 	
-    tdtool --"${input_arr[@]}"
+    ${input_arr[@]}
     
 done

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -72,14 +72,11 @@ while read -r input; do
     input="$(echo "$input" | jq --raw-output '.')"
     echo "[Info] Read alias: $input"
     
-	input_arr=()
+    input_arr=()
     for word in $input; do
         input_arr+=("$word")
-	done
+    done
 	
-    if ! msg="$(tdtool --"${input_arr[*]}")"; then
-    	echo "[Error] TellStick Command fails -> $msg"
-    else
-        echo "[Info] TellStick Command success -> $msg"
-    fi
+    tdtool --"${input_arr[@]}"
+    
 done

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -72,12 +72,12 @@ while read -r input; do
     input="$(echo "$input" | jq --raw-output '.')"
     echo "[Info] Read alias: $input"
     
-    input=("--$input")
-    input_arr=("tdtool")
+    input=("tdtool --$input")
+    input_arr=()
     for word in $input; do
         input_arr+=("$word")
     done
 	
-    ${input_arr[@]}
+    "${input_arr[@]}"
     
 done

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -71,8 +71,13 @@ while read -r input; do
     # removing JSON stuff
     input="$(echo "$input" | jq --raw-output '.')"
     echo "[Info] Read alias: $input"
-
-    if ! msg="$(tdtool --$input)"; then
+    
+	input_arr=()
+    for word in $input; do
+        input_arr+=("$word")
+	done
+	
+    if ! msg="$(tdtool --"${input_arr[@]}")"; then
     	echo "[Error] TellStick Command fails -> $msg"
     else
         echo "[Info] TellStick Command success -> $msg"

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -68,16 +68,14 @@ socat TCP-LISTEN:50801,reuseaddr,fork UNIX-CONNECT:/tmp/TelldusEvents &
 # Listen for input to tdtool
 echo "[Info] Starting event listener"
 while read -r input; do
-    # removing JSON stuff
-    input="$(echo "$input" | jq --raw-output '.')"
-    echo "[Info] Read alias: $input"
+    # parse JSON value
+    funct="$(echo "$input" | jq --raw-output '.function')"
+    devid="$(echo "$input" | jq --raw-output '.device // empty')"
+    echo "[Info] Read $funct / $devid"
     
-    input=("--$input")
-    input_arr=("tdtool")
-    for word in $input; do
-        input_arr+=("$word")
-    done
-	
-    "${input_arr[@]}"
-    
+    if ! msg="$(tdtool "--$funct" "$devid")"; then
+    	echo "[Error] TellStick "$funct" fails -> $msg"
+    else
+        echo "[Info] TellStick "$funct" success -> $msg"
+    fi
 done

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -77,7 +77,7 @@ while read -r input; do
         input_arr+=("$word")
 	done
 	
-    if ! msg="$(tdtool --${input_arr[@]})"; then
+    if ! msg="$(tdtool --"${input_arr[*]}")"; then
     	echo "[Error] TellStick Command fails -> $msg"
     else
         echo "[Info] TellStick Command success -> $msg"

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -72,7 +72,7 @@ while read -r input; do
     input="$(echo "$input" | jq --raw-output '.')"
     echo "[Info] Read alias: $input"
 
-    if ! msg="$(tdtool "--$input")"; then
+    if ! msg="$(tdtool --$input)"; then
     	echo "[Error] TellStick Command fails -> $msg"
     else
         echo "[Info] TellStick Command success -> $msg"

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -77,7 +77,7 @@ while read -r input; do
         input_arr+=("$word")
 	done
 	
-    if ! msg="$(tdtool --"${input_arr[@]}")"; then
+    if ! msg="$(tdtool --${input_arr[@]})"; then
     	echo "[Error] TellStick Command fails -> $msg"
     else
         echo "[Info] TellStick Command success -> $msg"

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -72,7 +72,7 @@ while read -r input; do
     input="$(echo "$input" | jq --raw-output '.')"
     echo "[Info] Read alias: $input"
 
-    if ! msg="$(tdtool --$input)"; then
+    if ! msg="$(tdtool --$'input')"; then
     	echo "[Error] TellStick Command fails -> $msg"
     else
         echo "[Info] TellStick Command success -> $msg"

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -74,7 +74,7 @@ while read -r input; do
     
     input=("tdtool --$input")
     input_arr=()
-    for word in $input; do
+    for word in ${input[@]}; do
         input_arr+=("$word")
     done
 	

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -72,7 +72,7 @@ while read -r input; do
     input="$(echo "$input" | jq --raw-output '.')"
     echo "[Info] Read alias: $input"
 
-    if ! msg="$(tdtool --$'input')"; then
+    if ! msg="$(tdtool --$input)"; then
     	echo "[Error] TellStick Command fails -> $msg"
     else
         echo "[Info] TellStick Command success -> $msg"

--- a/tellstick/run.sh
+++ b/tellstick/run.sh
@@ -74,8 +74,8 @@ while read -r input; do
     echo "[Info] Read $funct / $devid"
     
     if ! msg="$(tdtool "--$funct" "$devid")"; then
-    	echo "[Error] TellStick "$funct" fails -> $msg"
+    	echo "[Error] TellStick $funct fails -> $msg"
     else
-        echo "[Info] TellStick "$funct" success -> $msg"
+        echo "[Info] TellStick $funct success -> $msg"
     fi
 done


### PR DESCRIPTION
There is either something wrong with the handling of quotes when receiving input from json -> jq and parsing it to a quoted variable to bash.

Proof of concept to replicate below.


Created addon for test/play/verification: https://github.com/endor-force/stdin-addon
Service call: `{"addon":"local_stdintest","input":"l /"}`

```
#!/bin/bash
set -e

# Listen for input to tdtool
echo "[Info] Starting event listener"
while read -r input; do
    # removing JSON stuff
    input="$(echo "$input" | jq --join-output '.')"
    echo "[Info] Read alias: $input"
	
    if msg="$(ls -"$input")"; then
        echo "[Info] TellStick Command success -> $msg"
    fi
done
```

Sending data without spaces works.
But if you send `l /` (to run `ls -l /`) it will fail.