### PR TITLE
Fix StrictHostKeyChecking-related failure

### DIFF
--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "2.2",
+  "version": "2.3",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -10,11 +10,15 @@ AUTO_RESTART=$(jq --raw-output '.auto_restart' $CONFIG_PATH)
 REPEAT_ACTIVE=$(jq --raw-output '.repeat.active' $CONFIG_PATH)
 REPEAT_INTERVAL=$(jq --raw-output '.repeat.interval' $CONFIG_PATH)
 
-# prepare the private key, if provided
+# prepare ssh access, if the deployment key has been provided
 if [ ! -z "$DEPLOYMENT_KEY" ]; then
-    echo "[Info] setup deployment_key on id_${DEPLOYMENT_KEY_PROTOCOL}"
 
     mkdir -p ~/.ssh
+    echo "[Info] disable StrictHostKeyChecking for ssh"
+    echo "Host *" > ~/.ssh/config
+    echo "    StrictHostKeyChecking no" >> ~/.ssh/config
+
+    echo "[Info] setup deployment_key on id_${DEPLOYMENT_KEY_PROTOCOL}"
     while read -r line; do
         echo "$line" >> "${HOME}/.ssh/id_${DEPLOYMENT_KEY_PROTOCOL}"
     done <<< "$DEPLOYMENT_KEY"


### PR DESCRIPTION
For ssh-through git connections, the git pull fails because the host key will not be automatically added to known_hosts.

This should fix that by allowing the key to be put into the known_hosts.

Note that if the remote server ssh key changes, the git operation will fail. That seems a reasonably safe security fallback.