### PR TITLE
Update HASS-Configurator

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## 0.2.4
 - YAML lint support
+- Support new Hass.io token system

--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 0.2.4
+- YAML lint support

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Configurator",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "slug": "configurator",
   "description": "Browser-based configuration file editor for Home Assistant.",
   "url": "https://home-assistant.io/addons/configurator",

--- a/configurator/map.py
+++ b/configurator/map.py
@@ -1,5 +1,6 @@
 """Mapping hass.io options.json into configurator config."""
 import json
+import os
 from pathlib import Path
 import sys
 
@@ -12,7 +13,7 @@ with hassio_options.open('r') as json_file:
 configurator = {
     'BASEPATH': "/config",
     'HASS_API': "http://hassio/homeassistant/api/",
-    'HASS_API_PASSWORD': None,
+    'HASS_API_PASSWORD': os.environ.get('API_TOKEN'),
     'CREDENTIALS':
         "{}:{}".format(options['username'], options['password']),
     'SSL_CERTIFICATE':


### PR DESCRIPTION
The HASS-Configurator now has IPv6 support (irrelevant for hass.io I guess) and integrated linting of yaml. The latter change takes a lot of pain out of using the configurator! :)