### PR TITLE
Changing default challenge to http

### DIFF
--- a/letsencrypt/config.json
+++ b/letsencrypt/config.json
@@ -12,7 +12,7 @@
    },
   "map": ["ssl:rw"],
   "options": {
-    "challenge": "https",
+    "challenge": "http",
     "email": null,
     "domains": [null],
     "certfile": "fullchain.pem",


### PR DESCRIPTION
Let's Encrypt no longer supports TLS-SNI.
ref: https://github.com/home-assistant/home-assistant/issues/11676