### PR TITLE
Update HASS Configurator to 0.2.5

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.5
+- Added warning-logs for access failure
+- Added transparency to whitespace characters
+- Using external repository for Docker
+- Modify BANNED_IPS and ALLOWED_NETWORKS at runtime
+- Use relative paths in webserver
+- Added "Sesame" feature
+
 ## 0.2.4
 - YAML lint support
 - Support new Hass.io token system

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Configurator",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "slug": "configurator",
   "description": "Browser-based configuration file editor for Home Assistant.",
   "url": "https://home-assistant.io/addons/configurator",
@@ -22,7 +22,8 @@
     "banned_ips": ["8.8.8.8"],
     "banlimit": 0,
     "ignore_pattern": ["__pycache__"],
-    "dirsfirst": false
+    "dirsfirst": false,
+    "sesame": null
   },
   "schema": {
     "username": "str",
@@ -34,8 +35,8 @@
     "banned_ips": ["str"],
     "banlimit": "int",
     "ignore_pattern": ["str"],
-    "dirsfirst": "bool"
+    "dirsfirst": "bool",
+    "sesame": null
   },
   "image": "homeassistant/{arch}-addon-configurator"
 }
-  

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -22,8 +22,7 @@
     "banned_ips": ["8.8.8.8"],
     "banlimit": 0,
     "ignore_pattern": ["__pycache__"],
-    "dirsfirst": false,
-    "sesame": null
+    "dirsfirst": false
   },
   "schema": {
     "username": "str",
@@ -36,7 +35,7 @@
     "banlimit": "int",
     "ignore_pattern": ["str"],
     "dirsfirst": "bool",
-    "sesame": null
+    "sesame": "str?"
   },
   "image": "homeassistant/{arch}-addon-configurator"
 }

--- a/configurator/map.py
+++ b/configurator/map.py
@@ -25,6 +25,7 @@ configurator = {
     'IGNORE_PATTERN': options['ignore_pattern'],
     'BANLIMIT': options['banlimit'],
     'DIRSFIRST': options['dirsfirst'],
+    'SESAME': options['sesame'],
 }
 
 with Path(sys.argv[1]).open('w') as json_file:

--- a/configurator/map.py
+++ b/configurator/map.py
@@ -25,7 +25,7 @@ configurator = {
     'IGNORE_PATTERN': options['ignore_pattern'],
     'BANLIMIT': options['banlimit'],
     'DIRSFIRST': options['dirsfirst'],
-    'SESAME': options['sesame'],
+    'SESAME': options.get('sesame'),
 }
 
 with Path(sys.argv[1]).open('w') as json_file:

--- a/configurator/map.py
+++ b/configurator/map.py
@@ -13,7 +13,7 @@ with hassio_options.open('r') as json_file:
 configurator = {
     'BASEPATH': "/config",
     'HASS_API': "http://hassio/homeassistant/api/",
-    'HASS_API_PASSWORD': os.environ.get('API_TOKEN'),
+    'HASS_API_PASSWORD': os.environ.get('HASSIO_TOKEN', ''),
     'CREDENTIALS':
         "{}:{}".format(options['username'], options['password']),
     'SSL_CERTIFICATE':


### PR DESCRIPTION
Changes:
- Added warning-logs for access failure
- Added transparency to whitespace characters
- Using external repository for Docker
- Modify BANNED_IPS and ALLOWED_NETWORKS at runtime
- Use relative paths in webserver
- Added "Sesame" feature

Question:
The sesame parameter is optional. Is it ok to have it in the schema as `null` then? Or should it still be a string? In any case it should be possible to not set the parameter (`None` in Python) if people don't want to use it (for security reasons).
Alternatively we can use a special string ("none"?) and let the map.py convert that to a real `None`.