### PR TITLE
HASS Configurator 0.2.6

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.6
+- Displaying current filename in title
+- Added menu item to open configurator in new tab
+- Automatically load last viewed (and not closed) file via localStorage
+- CTRL+s / CMD+s can now be used to save files
+- Prompting before saving now opt-in in editor settings
+
 ## 0.2.5
 - Added warning-logs for access failure
 - Added transparency to whitespace characters

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Configurator",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "slug": "configurator",
   "description": "Browser-based configuration file editor for Home Assistant.",
   "url": "https://home-assistant.io/addons/configurator",


### PR DESCRIPTION
Changes:
- Displaying current filename in title
- Added menu item to open configurator in new tab
- Automatically load last viewed (and not closed) file via localStorage
- CTRL+s / CMD+s can now be used to save files
- Prompting before saving now opt-in in editor settings