### PR TITLE
GitPull: add support for ssh cloned GitHub repositories

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.1
+- Add support for key validation against ssh cloned GitHub repositories
+
 ## 4.0
 - Allow to use user/password authentication for GIT
 - New options `deployment_user` and `deployment_password`

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "4.0",
+  "version": "4.1",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -60,7 +60,7 @@ if [ -n "$DEPLOYMENT_KEY" ]; then
     echo "Check SSH connection"
     IFS=':' read -ra GIT_URL_PARTS <<< "$REPOSITORY"
     # shellcheck disable=SC2029
-    if ! ssh -T -o "BatchMode=yes" "${GIT_URL_PARTS[0]}"
+    if ! ssh -T -o "StrictHostKeyChecking=no" -o "BatchMode=yes" "${GIT_URL_PARTS[0]}"
     then
         echo "Valid SSH connection for ${GIT_URL_PARTS[0]}"
     else

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -60,11 +60,11 @@ if [ -n "$DEPLOYMENT_KEY" ]; then
     echo "Check SSH connection"
     IFS=':' read -ra GIT_URL_PARTS <<< "$REPOSITORY"
     # shellcheck disable=SC2029
-    if ! ssh -T -o "StrictHostKeyChecking=no" -o "BatchMode=yes" "${GIT_URL_PARTS[0]}"
-    then
-        echo "Valid SSH connection for ${GIT_URL_PARTS[0]}"
+    DOMAIN="${GIT_URL_PARTS[0]}"
+    if OUTPUT_CHECK=$(ssh -T -o "StrictHostKeyChecking=no" -o "BatchMode=yes" "$DOMAIN" 2>&1) || ([[ $DOMAIN = *"@github.com"* ]] && [[ $OUTPUT_CHECK = *"You've successfully authenticated"* ]]); then
+        echo "Valid SSH connection for $DOMAIN"
     else
-        echo "No valid SSH connection for ${GIT_URL_PARTS[0]}"
+        echo "No valid SSH connection for $DOMAIN"
         add-ssh-key
     fi
 fi


### PR DESCRIPTION
I tried to support the exit code/output returned by GitHub using a repository cloned using ssh (e.g. private repos, etc) accordingly [this official GitHub help page](https://help.github.com/articles/testing-your-ssh-connection/)