### PR TITLE
Let's encrypt fails (Status 301), update dehydrate

### DIFF
--- a/duckdns/Dockerfile
+++ b/duckdns/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG C.UTF-8
 
 # Setup base
 RUN apk add --no-cache jq curl libressl \
-  && curl -s -o /usr/bin/dehydrated https://raw.githubusercontent.com/lukas2511/dehydrated/v0.4.0/dehydrated \
+  && curl -s -o /usr/bin/dehydrated https://raw.githubusercontent.com/lukas2511/dehydrated/master/dehydrated \
   && chmod a+x /usr/bin/dehydrated
 
 # Copy data


### PR DESCRIPTION
Let's encrypt responds with "ERROR: An error occurred while sending get-request to http://cert.int-x3.letsencrypt.org/ (Status 301)". This was fixed in a recent commit to dehydrated. See:
* https://community.letsencrypt.org/t/dehydrated-caused-rate-limits-to-be-reached/52477
* https://github.com/lukas2511/dehydrated/commit/7a0e71c6c2ccc6e98abca5ea1c7de28053e90c02
* https://community.home-assistant.io/t/cant-get-lets-encrypt-working-with-hassio/25498/47