### PR TITLE
nginx_proxy: Update run.sh info messages, make HSTS configurable and optional

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## x.x
+- Update run.sh info messages
+
 ## 1.0
 - Add customization mechanism using included config snippets from /share
 - Optimize logo.png

--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## x.x
+## 1.1
 - Update run.sh info messages
 
 ## 1.0

--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1
 - Update run.sh info messages
+- Make HSTS configurable and optional
 
 ## 1.0
 - Add customization mechanism using included config snippets from /share

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -15,6 +15,7 @@
     "domain": null,
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
+    "hsts": "max-age=31536000; includeSubDomains",
     "customize": {
       "active": false,
       "default": "nginx_proxy_default*.conf",
@@ -25,6 +26,7 @@
     "domain": "str",
     "certfile": "str",
     "keyfile": "str",
+    "hsts": "str",
     "customize": {
       "active": "bool",
       "default": "str",

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "NGINX Home Assistant SSL proxy",
-  "version": "1.0",
+  "version": "1.1",
   "slug": "nginx_proxy",
   "description": "An SSL/TLS proxy",
   "url": "https://home-assistant.io/addons/nginx_proxy/",

--- a/nginx_proxy/nginx.conf
+++ b/nginx_proxy/nginx.conf
@@ -39,7 +39,7 @@ http {
         ssl_dhparam /data/dhparams.pem;
 
         listen [::]:443 http2;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+        %%HSTS%%
         ssl on;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";

--- a/nginx_proxy/run.sh
+++ b/nginx_proxy/run.sh
@@ -28,6 +28,7 @@ fi
 sed -i "s/%%FULLCHAIN%%/$CERTFILE/g" /etc/nginx.conf
 sed -i "s/%%PRIVKEY%%/$KEYFILE/g" /etc/nginx.conf
 sed -i "s/%%DOMAIN%%/$DOMAIN/g" /etc/nginx.conf
+
 [ -n "$HSTS" ] && HSTS="add_header Strict-Transport-Security \"$HSTS\";"
 sed -i "s/%%HSTS%%/$HSTS/g" /etc/nginx.conf
 

--- a/nginx_proxy/run.sh
+++ b/nginx_proxy/run.sh
@@ -10,6 +10,7 @@ SNAKEOIL_KEY=/data/ssl-cert-snakeoil.key
 DOMAIN=$(jq --raw-output ".domain" $CONFIG_PATH)
 KEYFILE=$(jq --raw-output ".keyfile" $CONFIG_PATH)
 CERTFILE=$(jq --raw-output ".certfile" $CONFIG_PATH)
+HSTS=$(jq --raw-output ".hsts // empty" $CONFIG_PATH)
 CUSTOMIZE_ACTIVE=$(jq --raw-output ".customize.active" $CONFIG_PATH)
 
 # Generate dhparams
@@ -27,6 +28,8 @@ fi
 sed -i "s/%%FULLCHAIN%%/$CERTFILE/g" /etc/nginx.conf
 sed -i "s/%%PRIVKEY%%/$KEYFILE/g" /etc/nginx.conf
 sed -i "s/%%DOMAIN%%/$DOMAIN/g" /etc/nginx.conf
+[ -n "$HSTS" ] && HSTS="add_header Strict-Transport-Security \"$HSTS\";"
+sed -i "s/%%HSTS%%/$HSTS/g" /etc/nginx.conf
 
 # Allow customize configs from share
 if [ "$CUSTOMIZE_ACTIVE" == "true" ]; then

--- a/nginx_proxy/run.sh
+++ b/nginx_proxy/run.sh
@@ -14,12 +14,12 @@ CUSTOMIZE_ACTIVE=$(jq --raw-output ".customize.active" $CONFIG_PATH)
 
 # Generate dhparams
 if [ ! -f "$DHPARAMS_PATH" ]; then
-    echo "[INFO] Generate dhparams..."
+    echo "[INFO] Generating dhparams (this will take some time)..."
     openssl dhparam -dsaparam -out "$DHPARAMS_PATH" 4096 > /dev/null
 fi
 
 if [ ! -f "$SNAKEOIL_CERT" ]; then
-    echo "[INFO] Create snakeoil (self-signed certificate)"
+    echo "[INFO] Creating 'snakeoil' self-signed certificate..."
     openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout $SNAKEOIL_KEY -out $SNAKEOIL_CERT -subj '/CN=localhost'
 fi
 
@@ -37,5 +37,5 @@ if [ "$CUSTOMIZE_ACTIVE" == "true" ]; then
 fi
 
 # start server
-echo "[INFO] Run nginx"
+echo "[INFO] Running nginx..."
 exec nginx -c /etc/nginx.conf < /dev/null


### PR DESCRIPTION
In particular, note that generating dhparams will take some time.