### PR TITLE
Add support for longer domain names in nginx_proxy

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2
+- Modify `server_names_hash_bucket_size` to add support for longer domain names
+
 ## 1.1
 - Update run.sh info messages
 - Make HSTS configurable and optional

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "NGINX Home Assistant SSL proxy",
-  "version": "1.1",
+  "version": "1.2",
   "slug": "nginx_proxy",
   "description": "An SSL/TLS proxy",
   "url": "https://home-assistant.io/addons/nginx_proxy/",

--- a/nginx_proxy/nginx.conf
+++ b/nginx_proxy/nginx.conf
@@ -10,6 +10,7 @@ http {
     map $http_upgrade $connection_upgrade {
         default upgrade;
         ''      close;
+    server_names_hash_bucket_size 64;
     }
 
     server {

--- a/nginx_proxy/nginx.conf
+++ b/nginx_proxy/nginx.conf
@@ -10,8 +10,9 @@ http {
     map $http_upgrade $connection_upgrade {
         default upgrade;
         ''      close;
-    server_names_hash_bucket_size 64;
     }
+    
+    server_names_hash_bucket_size 64;
 
     server {
         server_name _;


### PR DESCRIPTION
Fixes #243 

Currently, `server_names_hash_bucket_size` is set to `32`, which is fine in most cases but prevents longer domain names from working. In my case, I ran into the need to increase the size when creating a  `server_name` like the following: `subdomain.mydomain.duckdns.org`