### PR TITLE
Fixes schema error in Snips add-on

### DIFF
--- a/snips/config.json
+++ b/snips/config.json
@@ -41,7 +41,7 @@
     "language": "match((?:en|de|fr))",
     "custom_tts": {
       "active": "bool",
-      "platform": "string"
+      "platform": "str"
     }
   },
   "image": "homeassistant/{arch}-addon-snips"


### PR DESCRIPTION
Fixes an error in the Snips add-on `config.json` schema, causing the add-on not to be available at this moment.