### PR TITLE
Add server host and port options to nginx

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3
+- Add option for custom Homeassistant server host and port
+
 ## 1.2
 - Modify `server_names_hash_bucket_size` to add support for longer domain names
 

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "NGINX Home Assistant SSL proxy",
-  "version": "1.2",
+  "version": "1.3",
   "slug": "nginx_proxy",
   "description": "An SSL/TLS proxy",
   "url": "https://home-assistant.io/addons/nginx_proxy/",

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -13,6 +13,8 @@
   "map": ["ssl", "share"],
   "options": {
     "domain": null,
+    "server_host": "homeassistant",
+    "server_port": 8123,
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "hsts": "max-age=31536000; includeSubDomains",
@@ -24,6 +26,8 @@
   },
   "schema": {
     "domain": "str",
+    "server_host": "str",
+    "server_port": "port",
     "certfile": "str",
     "keyfile": "str",
     "hsts": "str",

--- a/nginx_proxy/nginx.conf
+++ b/nginx_proxy/nginx.conf
@@ -53,7 +53,7 @@ http {
         #include /share/nginx_proxy_default*.conf;
 
         location / {
-            proxy_pass http://homeassistant:8123;
+            proxy_pass http://%%SERVER_HOST%%:%%SERVER_PORT%%;
             proxy_set_header Host $host;
             proxy_redirect http:// https://;
             proxy_http_version 1.1;

--- a/nginx_proxy/run.sh
+++ b/nginx_proxy/run.sh
@@ -8,6 +8,8 @@ SNAKEOIL_CERT=/data/ssl-cert-snakeoil.pem
 SNAKEOIL_KEY=/data/ssl-cert-snakeoil.key
 
 DOMAIN=$(jq --raw-output ".domain" $CONFIG_PATH)
+SERVER_HOST=$(jq --raw-output ".server_host" $CONFIG_PATH)
+SERVER_PORT=$(jq --raw-output ".server_port" $CONFIG_PATH)
 KEYFILE=$(jq --raw-output ".keyfile" $CONFIG_PATH)
 CERTFILE=$(jq --raw-output ".certfile" $CONFIG_PATH)
 HSTS=$(jq --raw-output ".hsts // empty" $CONFIG_PATH)
@@ -28,6 +30,8 @@ fi
 sed -i "s/%%FULLCHAIN%%/$CERTFILE/g" /etc/nginx.conf
 sed -i "s/%%PRIVKEY%%/$KEYFILE/g" /etc/nginx.conf
 sed -i "s/%%DOMAIN%%/$DOMAIN/g" /etc/nginx.conf
+sed -i "s/%%SERVER_HOST%%/$SERVER_HOST/g" /etc/nginx.conf
+sed -i "s/%%SERVER_PORT%%/$SERVER_PORT/g" /etc/nginx.conf
 
 [ -n "$HSTS" ] && HSTS="add_header Strict-Transport-Security \"$HSTS\";"
 sed -i "s/%%HSTS%%/$HSTS/g" /etc/nginx.conf


### PR DESCRIPTION
This will add options to change the default home assistant host and port to the nginx addon.