### PR TITLE
Add PR template to show CLA link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+<!-- 
+Every contributor should sign the CLA (Contributor License Agreement) before we can merge any PR.
+
+You can sign it here: https://home-assistant.io/developers/cla_sign_start/
+
+If you have not signed the CLA and you submit a pull request, a link will be automatically generated. Just follow the link and the instructions.
+-->


### PR DESCRIPTION
This is a suggestion. Add a PR template with the CLA link, so the user can pre-sign it before opening the PR.

Feel free to close it, if you guys think it's not really necessary.