### PR TITLE
Disable guest access for Samba by default

### DIFF
--- a/samba/config.json
+++ b/samba/config.json
@@ -11,7 +11,7 @@
   "options": {
     "workgroup": "WORKGROUP",
     "name": "hassio",
-    "guest": true,
+    "guest": false,
     "map": {
       "config": true,
       "addons": true,


### PR DESCRIPTION
By default, the Samba add-on is too open. Guest access + write access to config and other add-ons means that it's easy to take control of the system. Let's disable guest access by default (users could still enable it) so that we try to steer users to add username/password.

Also wondering if we can limit Samba by default to the local subnets?