### PR TITLE
ssh: Include hassio bash completion

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.1
+- Include hassio bash completion
+
 ## 4
 - Update Hass.io CLI to 1.4.0
 - Add new API role profile

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -21,7 +21,8 @@ ARG BUILD_ARCH
 ARG CLI_VERSION
 RUN apk add --no-cache curl \
     && curl -Lso /usr/bin/hassio https://github.com/home-assistant/hassio-cli/releases/download/${CLI_VERSION}/hassio_${BUILD_ARCH} \
-    && chmod a+x /usr/bin/hassio
+    && chmod a+x /usr/bin/hassio \
+    && curl -Lso /usr/share/bash-completion/completions/hassio https://raw.githubusercontent.com/home-assistant/hassio-cli/${CLI_VERSION}/hassio.bash
 
 # Copy data
 COPY run.sh /

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "SSH server",
-  "version": "4",
+  "version": "4.1",
   "slug": "ssh",
   "description": "Allows connections over SSH",
   "url": "https://home-assistant.io/addons/ssh/",


### PR DESCRIPTION
Note: this should not be merged before the next version of hassio-cli that includes the completion is out. Filing already now as a reminder.