### PR TITLE
Update Configurator to version 0.2.9

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.4
+- Update Configurator to version 0.2.9
+- Material Icons and HASS-help now open in new tab instead of modal
+- Open file by URL
+- Added ENFORCE_BASEPATH option
+- Cosmetic fix for scaled viewports
+- Added search-function for entities
+- Updated Ace Editor to 1.3.3
+- Updated jQuery to 3.3.1
+- Updated js-yaml to 3.12.0
+
 ## 0.3
 - Update Configurator to version 0.2.8
 

--- a/configurator/build.json
+++ b/configurator/build.json
@@ -1,5 +1,5 @@
 {
   "args": {
-    "CONFIGURATOR_VERSION": "0.2.8"
+    "CONFIGURATOR_VERSION": "0.2.9"
   }
 }

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Configurator",
-  "version": "0.3",
+  "version": "0.4",
   "slug": "configurator",
   "description": "Browser-based configuration file editor for Home Assistant.",
   "url": "https://home-assistant.io/addons/configurator",
@@ -18,11 +18,12 @@
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "ssl": false,
-    "allowed_networks": ["192.168.0.0/16"],
+    "allowed_networks": ["192.168.0.0/16", "172.30.0.0/16"],
     "banned_ips": ["8.8.8.8"],
     "banlimit": 0,
     "ignore_pattern": ["__pycache__"],
-    "dirsfirst": false
+    "dirsfirst": false,
+    "enforce_basepath": false
   },
   "schema": {
     "username": "str",
@@ -35,6 +36,7 @@
     "banlimit": "int",
     "ignore_pattern": ["str"],
     "dirsfirst": "bool",
+    "enforce_basepath": "bool",
     "sesame": "str?",
     "verify_hostname": "str?"
   },

--- a/configurator/map.py
+++ b/configurator/map.py
@@ -12,6 +12,7 @@ with hassio_options.open('r') as json_file:
 
 configurator = {
     'BASEPATH': "/config",
+    'ENFORCE_BASEPATH': options['enforce_basepath'],
     'HASS_API': "http://hassio/homeassistant/api/",
     'HASS_API_PASSWORD': os.environ.get('HASSIO_TOKEN', ''),
     'CREDENTIALS':


### PR DESCRIPTION
Updating Configurator to version 0.2.9.
This includes the following changes:

- Material Icons and HASS-help now open in new tab instead of modal
- Open file by URL
- Added ENFORCE_BASEPATH option
- Cosmetic fix for scaled viewports
- Added search-function for entities
- Updated Ace Editor to 1.3.3
- Updated jQuery to 3.3.1
- Updated js-yaml to 3.12.0