### PR TITLE
Modify git_pull to support reset as well as pull

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.8
+- Add option to use git reset instead of git pull
+- Validate git origin URL
+
 ## 4.7
 - Update Hass.io CLI to 1.3.1
 

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "4.7",
+  "version": "4.8",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",
@@ -13,6 +13,9 @@
     "deployment_key_protocol": "rsa",
     "deployment_user": "",
     "deployment_password": "",
+    "git_branch": "master",
+    "git_command": "pull",
+    "git_remote": "origin",
     "repository": null,
     "auto_restart": false,
     "repeat": {
@@ -25,6 +28,9 @@
     "deployment_key_protocol": "match(rsa|dsa|ecdsa|ed25519|rsa)",
     "deployment_user": "str",
     "deployment_password": "str",
+    "git_branch": "str",
+    "git_command": "match(pull|reset)",
+    "git_remote": "str",
     "repository": "match((?:.+):(\/\/)?(.*?)(\\.git)(\/?|\\#[-\\d\\w._]+?))",
     "auto_restart": "bool",
     "repeat": {

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -116,7 +116,8 @@ function git-synchronize {
         echo "[Info] Local git repository exists"
 
         # Is the local repo set to the correct origin?
-        if [ "$(git remote get-url --all \"$GIT_REMOTE\" | head -n 1)" = "$REPOSITORY" ]
+        CURRENTGITREMOTEURL=$(git remote get-url --all "$GIT_REMOTE" | head -n 1)
+        if [ "$CURRENTGITREMOTEURL" = "$REPOSITORY" ]
         then
             echo "[Info] Git origin is correctly set to $REPOSITORY"
             OLD_COMMIT=$(git rev-parse HEAD)

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -116,7 +116,7 @@ function git-synchronize {
         echo "[Info] Local git repository exists"
 
         # Is the local repo set to the correct origin?
-        if [ "$(git remote get-url --all $GIT_REMOTE | head -n 1)" = "$REPOSITORY" ]
+        if [ "$(git remote get-url --all \"$GIT_REMOTE\" | head -n 1)" = "$REPOSITORY" ]
         then
             echo "[Info] Git origin is correctly set to $REPOSITORY"
             OLD_COMMIT=$(git rev-parse HEAD)
@@ -125,14 +125,14 @@ function git-synchronize {
             case "$GIT_COMMAND" in
                 pull)
                     echo "[Info] Start git pull..."
-                    git checkout $GIT_BRANCH || { echo "[Error] Git checkout failed"; exit 1; }
+                    git checkout "$GIT_BRANCH" || { echo "[Error] Git checkout failed"; exit 1; }
                     git pull || { echo "[Error] Git pull failed"; exit 1; }
                     ;;
                 reset)
                     echo "[Info] Start git reset..."
-                    git checkout $GIT_BRANCH || { echo "[Error] Git checkout failed"; exit 1; }
-                    git fetch $GIT_REMOTE $GIT_BRANCH || { echo "[Error] Git fetch failed"; exit 1; }
-                    git reset --hard $GIT_REMOTE/$GIT_BRANCH || { echo "[Error] Git reset failed"; exit 1; }
+                    git checkout "$GIT_BRANCH" || { echo "[Error] Git checkout failed"; exit 1; }
+                    git fetch "$GIT_REMOTE" "$GIT_BRANCH" || { echo "[Error] Git fetch failed"; exit 1; }
+                    git reset --hard "$GIT_REMOTE"/"$GIT_BRANCH" || { echo "[Error] Git reset failed"; exit 1; }
                     ;;
                 *)
                     echo "[Error] Git command is not set correctly. Should be either 'reset' or 'pull'"

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -19,7 +19,7 @@ REPEAT_INTERVAL=$(jq --raw-output '.repeat.interval' $CONFIG_PATH)
 
 #### functions ####
 function add-ssh-key {
-    echo "Start adding SSH key"
+    echo "[Info] Start adding SSH key"
     mkdir -p ~/.ssh
 
     (
@@ -27,7 +27,7 @@ function add-ssh-key {
         echo "    StrictHostKeyChecking no"
     ) > ~/.ssh/config
 
-    echo "Setup deployment_key on id_${DEPLOYMENT_KEY_PROTOCOL}"
+    echo "[Info] Setup deployment_key on id_${DEPLOYMENT_KEY_PROTOCOL}"
     while read -r line; do
         echo "$line" >> "${HOME}/.ssh/id_${DEPLOYMENT_KEY_PROTOCOL}"
     done <<< "$DEPLOYMENT_KEY"
@@ -39,7 +39,7 @@ function add-ssh-key {
 function git-clone {
     # create backup
     BACKUP_LOCATION="/tmp/config-$(date +%Y-%m-%d_%H-%M-%S)"
-    echo "Backup configuration to $BACKUP_LOCATION"
+    echo "[Info] Backup configuration to $BACKUP_LOCATION"
     
     mkdir "${BACKUP_LOCATION}" || { echo "[Error] Creation of backup directory failed"; exit 1; }
     cp -rf /config/* "${BACKUP_LOCATION}" || { echo "[Error] Copy files to backup directory failed"; exit 1; }
@@ -48,7 +48,7 @@ function git-clone {
     rm -rf /config/{,.[!.],..?}* || { echo "[Error] Clearing /config failed"; exit 1; }
 
     # git clone
-    echo "Start git clone"
+    echo "[Info] Start git clone"
     git clone "$REPOSITORY" /config || { echo "[Error] Git clone failed"; exit 1; }
 
     # try to copy non yml files back
@@ -65,9 +65,9 @@ if [ -n "$DEPLOYMENT_KEY" ]; then
     # shellcheck disable=SC2029
     DOMAIN="${GIT_URL_PARTS[0]}"
     if OUTPUT_CHECK=$(ssh -T -o "StrictHostKeyChecking=no" -o "BatchMode=yes" "$DOMAIN" 2>&1) || { [[ $DOMAIN = *"@github.com"* ]] && [[ $OUTPUT_CHECK = *"You've successfully authenticated"* ]]; }; then
-        echo "Valid SSH connection for $DOMAIN"
+        echo "[Info] Valid SSH connection for $DOMAIN"
     else
-        echo "No valid SSH connection for $DOMAIN"
+        echo "[Warn] No valid SSH connection for $DOMAIN"
         add-ssh-key
     fi
 fi
@@ -113,23 +113,23 @@ function git-synchronize {
     # is /config a local git repo?
     if git rev-parse --is-inside-git-dir &>/dev/null
     then
-        echo "Git repository exists"
+        echo "[Info] Local git repository exists"
 
         # Is the local repo set to the correct origin?
         if [ "$(git remote get-url --all $GIT_REMOTE | head -n 1)" = "$REPOSITORY" ]
         then
-            echo "Git origin is correctly set to $REPOSITORY"
+            echo "[Info] Git origin is correctly set to $REPOSITORY"
             OLD_COMMIT=$(git rev-parse HEAD)
             
             # Pull or reset depending on user preference
             case "$GIT_COMMAND" in
                 pull)
-                    echo "Start git pull..."
+                    echo "[Info] Start git pull..."
                     git checkout $GIT_BRANCH || { echo "[Error] Git checkout failed"; exit 1; }
                     git pull || { echo "[Error] Git pull failed"; exit 1; }
                     ;;
                 reset)
-                    echo "Start git reset..."
+                    echo "[Info] Start git reset..."
                     git checkout $GIT_BRANCH || { echo "[Error] Git checkout failed"; exit 1; }
                     git fetch $GIT_REMOTE $GIT_BRANCH || { echo "[Error] Git fetch failed"; exit 1; }
                     git reset --hard $GIT_REMOTE/$GIT_BRANCH || { echo "[Error] Git reset failed"; exit 1; }
@@ -144,7 +144,7 @@ function git-synchronize {
         fi
 
     else
-        echo "git repostory doesn't exist"
+        echo "[Warn] Git repostory doesn't exist"
         git-clone
     fi
 }
@@ -154,16 +154,16 @@ function validate-config {
     # Compare commit ids & check config
     NEW_COMMIT=$(git rev-parse HEAD)
     if [ "$NEW_COMMIT" != "$OLD_COMMIT" ]; then
-        echo "[Info] check Home-Assistant config"
+        echo "[Info] Something has changed, check Home-Assistant config"
         if hassio homeassistant check; then
             if [ "$AUTO_RESTART" == "true" ]; then
-                echo "[Info] restart Home-Assistant"
+                echo "[Info] Restart Home-Assistant"
                 hassio homeassistant restart 2&> /dev/null
             else
                 echo "[Info] Local configuraiton has changed. Restart requried."
             fi
         else
-            echo "[Error] invalid config!"
+            echo "[Error] Configuration updated but it does not pass the config check. Do not restart until this is fixed!"
         fi
     else
         echo "[Info] Nothing has changed."


### PR DESCRIPTION
I have been using this git pull plugin but it used to complain that the local files had been modified when they hadn't. I could successfully do a git pull using remote tools like vscode but this plugin would fail.  So, I wanted to add an option to support ```git reset --hard``` to support overwriting local changes with the remote.

This has been exposed using an additional option called git_command.  This can be pull (default) or reset.

Other changes:
- I have also added a check that the local git repo is set to the correct remote URL.
- I have added 2 extra options to allow for the branch and remote names being non-standard. Sensible defaults have been specified for each.
- Modified the validate config function to report when there are changes even if auto restart is off

Am happy to update the docs if this is merged.