### PR TITLE
Fix configurator SSL certificate path

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 0.5
+## 1.1
+- Fixed ssl certificate path bug
+
+## 1.0
 - Added basic git stash functionality
 - Added NOTIFY_SERVICE option
 - Notifying if used passwords are insecure and when SESAME has been used

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Configurator",
-  "version": "1.0",
+  "version": "1.1",
   "slug": "configurator",
   "description": "Browser-based configuration file editor for Home Assistant.",
   "url": "https://home-assistant.io/addons/configurator",

--- a/configurator/run.sh
+++ b/configurator/run.sh
@@ -23,8 +23,8 @@ export HC_VERIFY_HOSTNAME=$(jq --raw-output '.verify_hostname // empty' $CONFIG_
 
 SSL=$(jq --raw-output '.ssl // false' $CONFIG_PATH)
 if  [ "$SSL" == "true" ]; then
-    export HC_SSL_CERTIFICATE=$(jq --raw-output '.certfile' $CONFIG_PATH)
-    export HC_SSL_KEY=$(jq --raw-output '.keyfile' $CONFIG_PATH)
+    export HC_SSL_CERTIFICATE=ssl/$(jq --raw-output '.certfile' $CONFIG_PATH)
+    export HC_SSL_KEY=ssl/$(jq --raw-output '.keyfile' $CONFIG_PATH)
 fi
 
 LOGLEVEL=$(jq --raw-output '.loglevel // empty' $CONFIG_PATH)


### PR DESCRIPTION
Related to #365 

From the git history, I validated that it's missing the `ssl/` prefix on the SSL certificate path:

https://github.com/home-assistant/hassio-addons/commit/07f7634e94b9735ed64170baf559237cc3e81a24#diff-09708b1dcc1af14a9dc0f5ea06b24edfL21

https://github.com/home-assistant/hassio-addons/commit/07f7634e94b9735ed64170baf559237cc3e81a24#diff-09708b1dcc1af14a9dc0f5ea06b24edfL23