### PR TITLE
check_config: do not copy config to /tmp on start - #374

### DIFF
--- a/check_config/config.json
+++ b/check_config/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Check Home Assistant configuration",
-  "version": "0.7",
+  "version": "0.8",
   "slug": "check_config",
   "description": "Check current Home Assistant configuration against a new version",
   "url": "https://home-assistant.io/addons/check_config/",

--- a/check_config/run.sh
+++ b/check_config/run.sh
@@ -22,8 +22,7 @@ fi
 
 echo "[Info] Install done, check config now"
 
-cp -r /config /tmp/config > /dev/null
-if ! HASS_OUTPUT="$(hass -c /tmp/config --script check_config)"
+if ! HASS_OUTPUT="$(hass -c /config --script check_config)"
 then
     echo "[Error] Wrong config found!"
     echo "$HASS_OUTPUT"


### PR DESCRIPTION
https://github.com/home-assistant/hassio-addons/issues/374


I just made this change for myself, to be able to run this addon standalone on my dev machine.

Please feel free to reject this PR if there is indeed a valid reason to copy the config to /tmp first - in that case I will modify it to first remove the config in /tmp before copying.

Thx