### PR TITLE
Map Hass.io backup and share folders

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0
+## 1.3
 - Add access to folder: `/share`, `/backup`
 
 ## 1.2

--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.3
+## 2
 - Add access to folder: `/share`, `/backup`
 
 ## 1.2

--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0
+- Add access to folder: `/share`, `/backup`
+
 ## 1.2
 
 ### Configurator 0.3.2

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -15,7 +15,7 @@
     "backup:rw",
     "config:rw",
     "share:rw",
-    "ssl"
+    "ssl:rw"
   ],
   "options": {
     "username": "admin",

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Configurator",
-  "version": "2.0",
+  "version": "1.2",
   "slug": "configurator",
   "description": "Browser-based configuration file editor for Home Assistant.",
   "url": "https://home-assistant.io/addons/configurator",

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Configurator",
-  "version": "1.2",
+  "version": "2.0",
   "slug": "configurator",
   "description": "Browser-based configuration file editor for Home Assistant.",
   "url": "https://home-assistant.io/addons/configurator",

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -11,7 +11,12 @@
   "ports": {
     "3218/tcp": 3218
   },
-  "map": ["config:rw", "ssl"],
+  "map": [
+    "backup:rw",
+    "config:rw",
+    "share:rw",
+    "ssl"
+  ],
   "options": {
     "username": "admin",
     "password": null,

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Configurator",
-  "version": "1.2",
+  "version": "1.3",
   "slug": "configurator",
   "description": "Browser-based configuration file editor for Home Assistant.",
   "url": "https://home-assistant.io/addons/configurator",

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Configurator",
-  "version": "1.3",
+  "version": "2",
   "slug": "configurator",
   "description": "Browser-based configuration file editor for Home Assistant.",
   "url": "https://home-assistant.io/addons/configurator",


### PR DESCRIPTION
This PR gives the configurator add-on rw rights to backup, share and ssl. Some add-ons (like the unifi, caddy, a mkdocs add-on I personally use...) store and use files in those folders. It would be nice to be able to edit those files when not at home with samba (and not needing to do it all using a SSH terminal).

For example:
- automated backups of the UniFi Controller add-on are created in /backup/unifi. Now a user could download those backups using Configurator.
- the Caddy add-on uses a Caddyfile, which is stored in /share/caddy, now a user can edit this config file with Configurator as well.
- and at last, rw-access to /ssl in case a user wants or needs to delete a certificate or private key file.
