### PR TITLE
Samba: Disabling guest mode by default

### DIFF
--- a/samba/config.json
+++ b/samba/config.json
@@ -11,7 +11,7 @@
   "options": {
     "workgroup": "WORKGROUP",
     "name": "hassio",
-    "guest": true,
+    "guest": false,
     "map": {
       "config": true,
       "addons": true,


### PR DESCRIPTION
I am concerned that by default the Samba add-on allow anyone on the local network to see the entire configuration and secrets. I propose to disable guest mode by default.

You also risk to inadvertently expose the entire configuration to the Internet if you open the Samba ports for remote access.

This is a potential breaking change for users of the add-on.

Note to self: Update documentation afterwards.

(I'm not 100% sure if a pull request is the right place to start this discussion. Please tell me if this in-appropriate.)