### PR TITLE
Support the changes in specific files without restarting home assistant

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6
+- Allow to disable Home Assistant restart for specific file changes
+
 ## 5
 - Update Hass.io CLI to 1.4.0
 - Add new API role profile

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "5.0.1",
+  "version": "6",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "5",
+  "version": "5.0.1",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",
@@ -20,6 +20,10 @@
     "git_prune": false,
     "repository": null,
     "auto_restart": false,
+    "restart_ignore": [
+      "ui-lovelace.yaml",
+      ".gitignore"
+    ],
     "repeat": {
       "active": false,
       "interval": 300
@@ -36,6 +40,7 @@
     "git_prune": "bool",
     "repository": "match((?:.+):(\/\/)?(.*?)(\\.git)(\/?|\\#[-\\d\\w._]+?))",
     "auto_restart": "bool",
+    "restart_ignore": ["str"],
     "repeat": {
       "active": "bool",
       "interval": "int"

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -183,7 +183,7 @@ function validate-config {
                 echo "Changed Files: $CHANGED_FILES"
                 if [ -n "$RESTART_IGNORED_FILES" ]; then
                     for file in $CHANGED_FILES; do
-                        echo "$RESTART_IGNORED_FILES" | grep -qw "${file}""
+                        echo "$RESTART_IGNORED_FILES" | grep -qw "${file}"
                         if [ $? -eq 1 ] ; then
                             DO_RESTART="true"
                             echo "[Info] Detected Restart Required File $file"

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -179,18 +179,18 @@ function validate-config {
         if hassio homeassistant check; then
             if [ "$AUTO_RESTART" == "true" ]; then
                 DO_RESTART="false"
-                CHANGED_FILES=$(git diff $OLD_COMMIT .. $NEW_COMMIT --name-only)
+                CHANGED_FILES=$(git diff "$OLD_COMMIT" .. "$NEW_COMMIT" --name-only)
                 echo "Changed Files: $CHANGED_FILES"
                 if [ -n "$RESTART_IGNORED_FILES" ]; then
                     for file in $CHANGED_FILES; do
-                        echo $RESTART_IGNORED_FILES | grep -qw ${file}
+                        echo "$RESTART_IGNORED_FILES" | grep -qw "${file}""
                         if [ $? -eq 1 ] ; then
                             DO_RESTART="true"
                             echo "[Info] Detected Restart Required File $file"
                         fi
                     done
                 else
-                    DO_RESTART = "true"
+                    DO_RESTART="true"
                 fi
                 if [ "$DO_RESTART" == "true" ]; then
                     echo "[Info] Restart Home-Assistant"

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -181,7 +181,7 @@ function validate-config {
                 DO_RESTART="false"
                 CHANGED_FILES=$(git diff $OLD_COMMIT .. $NEW_COMMIT --name-only)
                 echo "Changed Files: $CHANGED_FILES"
-                if [ -n "$RESTART_IGNORED_FILES"]; then
+                if [ -n "$RESTART_IGNORED_FILES" ]; then
                     for file in $CHANGED_FILES; do
                         echo $RESTART_IGNORED_FILES | grep -qw ${file}
                         if [ $? -eq 1 ] ; then
@@ -192,7 +192,7 @@ function validate-config {
                 else
                     DO_RESTART = "true"
                 fi
-                if [ "$DO_RESTART" == "true"]; then
+                if [ "$DO_RESTART" == "true" ]; then
                     echo "[Info] Restart Home-Assistant"
                     hassio homeassistant restart 2&> /dev/null
                 else


### PR DESCRIPTION
Support the changes in specific files without restarting home assistant.  Files such as the lovelace config can be picked up without a restart of the service, decreasing impact of changes.

Especially since services like zwave take time to start back up after a reload, any time we can incorporate change without a restart is a bonus for the user experience.  