### PR TITLE
git_pull: fix for home-assistant/hassio-addons#480

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.1
+- Bugfix in git diff command while comparing branches
+
 ## 6
 - Allow to disable Home Assistant restart for specific file changes
 

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "6",
+  "version": "6.1",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -179,7 +179,7 @@ function validate-config {
         if hassio homeassistant check; then
             if [ "$AUTO_RESTART" == "true" ]; then
                 DO_RESTART="false"
-                CHANGED_FILES=$(git diff "$OLD_COMMIT" .. "$NEW_COMMIT" --name-only)
+                CHANGED_FILES=$(git diff "$OLD_COMMIT" "$NEW_COMMIT" --name-only)
                 echo "Changed Files: $CHANGED_FILES"
                 if [ -n "$RESTART_IGNORED_FILES" ]; then
                     for file in $CHANGED_FILES; do


### PR DESCRIPTION
Fix the `git diff` command which renders the add-on inoperable.
See home-assistant/hassio-addons#480.

Tested and found ok.