### PR TITLE
Homematic OCCU: Fix write error when starting OCCU due to missing status directory

### DIFF
--- a/homematic/Dockerfile
+++ b/homematic/Dockerfile
@@ -20,6 +20,7 @@ RUN curl -SL https://github.com/eq-3/occu/archive/${OCCU_VERSION}.tar.gz | tar x
     && mkdir -p /opt/hm/etc/config \
     && mkdir -p /opt/HmIP \
     && mkdir -p /opt/HMServer \
+    && mkdir -p /var/status \
     && mkdir -p /boot \
     && echo "VERSION=${OCCU_VERSION}" > /boot/VERSION \
     && ln -s /opt/hm/etc/config /etc/config \


### PR DESCRIPTION
HMIPServer writes a lock file to `/var/status/HMServerStarted`, so create directory `/var/status` to prevent an exception that may confuse users.