### PR TITLE
Homematic OCCU: Supply custom log4j configuration for HMIPServer to log to console

### DIFF
--- a/homematic/Dockerfile
+++ b/homematic/Dockerfile
@@ -39,17 +39,16 @@ RUN curl -SL https://github.com/eq-3/occu/archive/${OCCU_VERSION}.tar.gz | tar x
     && cd ../ \
     && cp -r firmware / \
     && mv /firmware/HmIP-RFUSB/hmip_coprocessor_update.eq3 /firmware/HmIP-RFUSB/hmip_coprocessor_update-2.8.6.eq3 \
-    && cp -R HMserver/etc/config_templates/* /opt/hm/etc/config/ \
     && cp -R HMserver/opt/HmIP/* /opt/HmIP/ \
     && cp -a HMserver/opt/HMServer/HMIPServer.jar /opt/HMServer/ \
     && cp -R HMserver/opt/HMServer/groups /opt/HMServer/ \
-	&& cp -R HMserver/opt/HMServer/measurement /opt/HMServer/ \
-	&& cp -R HMserver/opt/HMServer/pages /opt/HMServer/ \
+    && cp -R HMserver/opt/HMServer/measurement /opt/HMServer/ \
+    && cp -R HMserver/opt/HMServer/pages /opt/HMServer/ \
     && rm -rf /usr/src/occu-${OCCU_VERSION}
 ENV HM_HOME=/opt/hm LD_LIBRARY_PATH=/opt/hm/lib:${LD_LIBRARY_PATH}
 
 # Update config files
-COPY rfd.conf hs485d.conf crRFD.conf /etc/config/
+COPY rfd.conf hs485d.conf crRFD.conf log4j.xml /etc/config/
 
 # Setup start script
 COPY run.sh /

--- a/homematic/log4j.xml
+++ b/homematic/log4j.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+
+	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%d [%p] %c{1} - %m%n" />
+		</layout>
+	</appender>
+
+	<category name="de.eq3">
+		<priority value="INFO" />
+	</category>
+	<category name="org">
+		<priority value="INFO" />
+	</category>
+	<category name="com">
+		<priority value="INFO" />
+	</category>
+
+	<root>
+		<priority value="ERROR" />
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</log4j:configuration>


### PR DESCRIPTION
This allows reading the HMIPServer log via the docker log file.
The default configuration logs to file and syslog which is not accessible from outside the docker container.