### PR TITLE
Improve wording in Git Pull output

### DIFF
--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -171,11 +171,11 @@ function git-synchronize {
 }
 
 function validate-config {
-    echo "[Info] Check if something is changed"
+    echo "[Info] Checking if something has changed..."
     # Compare commit ids & check config
     NEW_COMMIT=$(git rev-parse HEAD)
     if [ "$NEW_COMMIT" != "$OLD_COMMIT" ]; then
-        echo "[Info] Something has changed, check Home-Assistant config"
+        echo "[Info] Something has changed, checking Home-Assistant config..."
         if hassio homeassistant check; then
             if [ "$AUTO_RESTART" == "true" ]; then
                 DO_RESTART="false"


### PR DESCRIPTION
Currently an example output is:

```sh
Updating ed47959..2da4bb6
Fast-forward
 configuration.yaml | 1 +
 1 file changed, 1 insertion(+)
[Info] Check if something is changed
[Info] Something has changed, check Home-Assistant config
```

For a while I thought the last line was an instruction to the user, especially since this config check seems to take the longest to complete.

This PR improves the wording of the last two lines to make it clearer what's happening:

```sh
Updating ed47959..2da4bb6
Fast-forward
 configuration.yaml | 1 +
 1 file changed, 1 insertion(+)
[Info] Checking if something has changed...
[Info] Something has changed, checking Home-Assistant config...
```