### PR TITLE
Show the installed homeassistant version in check_config

### DIFF
--- a/check_config/run.sh
+++ b/check_config/run.sh
@@ -20,7 +20,9 @@ then
     exit 1
 fi
 
-echo "[Info] Install done, check config now"
+INSTALLED_VERSION="$(pip freeze | grep homeassistant)"
+
+echo "[Info] Installed $INSTALLED_VERSION, check config now"
 
 cp -fr /config /tmp/config
 if ! HASS_OUTPUT="$(hass -c /tmp/config --script check_config)"


### PR DESCRIPTION
This can be useful if you use "latest" but are not sure which version is
the latest or if you look at the log output and it isn't clear if the
addon was ran since the latest release.