### PR TITLE
Add hint to clarify Configurator needs password for running

### DIFF
--- a/configurator/config.json
+++ b/configurator/config.json
@@ -19,7 +19,7 @@
   ],
   "options": {
     "username": "admin",
-    "password": null,
+    "password": "admin",
     "ssl": false,
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -2,7 +2,7 @@
   "name": "Configurator",
   "version": "2",
   "slug": "configurator",
-  "description": "Browser-based configuration file editor for Home Assistant.",
+  "description": "Browser-based configuration file editor (don't forget to set a password in the configuration after install)",
   "url": "https://home-assistant.io/addons/configurator",
   "startup": "application",
   "webui": "[PROTO:ssl]://[HOST]:[PORT:3218]",

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -19,7 +19,7 @@
   ],
   "options": {
     "username": "admin",
-    "password": "admin",
+    "password": null,
     "ssl": false,
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",


### PR DESCRIPTION
As explained in #492, the current default config does not allow the addon to be started. This password should allow the addon to run without modification and therefore remove a source of frustration for users.