### PR TITLE
ssh: Include hassio bash completion

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 5.0
-- Update Hass.io CLI to 2.0.1
+- Update Hass.io CLI to 2.0.1, include bash completion
 
 ## 4.0
 - Update Hass.io CLI to 1.4.0

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -21,7 +21,8 @@ ARG BUILD_ARCH
 ARG CLI_VERSION
 RUN apk add --no-cache curl \
     && curl -Lso /usr/bin/hassio https://github.com/home-assistant/hassio-cli/releases/download/${CLI_VERSION}/hassio_${BUILD_ARCH} \
-    && chmod a+x /usr/bin/hassio
+    && chmod a+x /usr/bin/hassio \
+    && /usr/bin/hassio completion | sed "s/hassio-cli/hassio/g" > /usr/share/bash-completion/completions/hassio
 
 # Copy data
 COPY run.sh /


### PR DESCRIPTION
This is #322 but for hassio-cli version 2, to the cli-2.0.1 branch.

The sed is there to fix/workaround https://github.com/home-assistant/hassio-cli/issues/140