### PR TITLE
git_pull: don't break repeating function when internet connection lost once

### DIFF
--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -215,10 +215,13 @@ function validate-config {
 cd /config || { echo "[Error] Failed to cd into /config"; exit 1; }
 
 while true; do
-    check-ssh-key
-    setup-user-password
-    git-synchronize
-    validate-config
+    if check-ssh-key ; then
+        if setup-user-password ; then
+            if git-synchronize ; then
+                validate-config
+            fi
+        fi
+    fi
      # do we repeat?
     if [ ! "$REPEAT_ACTIVE" == "true" ]; then
         exit 0


### PR DESCRIPTION
Problem: if repeat_interval is set, but internet connection is not available during a check, the script exits and the repeating function is broken. This should be solved by the change, and by the if statements it's still ensured that the following step is only executed if the previous exited without an error