### PR TITLE
SSH: Enables auto mapping of all UART/Serial devices

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.1
+- Map all serial devices into container for manual adjustments
+
 ## 5.0
 - Update Hass.io CLI to 2.0.1, include bash completion
 

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -8,6 +8,7 @@
   "boot": "auto",
   "hassio_api": true,
   "hassio_role": "manager",
+  "auto_uart": true,
   "ports": {
     "22/tcp": 22
    },

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "SSH server",
-  "version": "5.0",
+  "version": "5.1",
   "slug": "ssh",
   "description": "Allows connections over SSH",
   "url": "https://home-assistant.io/addons/ssh/",


### PR DESCRIPTION
Added `auto_uart` on the SSH add-on in order to expose UART/Serial devices inside the SSH add-on.

This allows users to do basic things with their serial devices and prevents workarounds like:

home-assistant/home-assistant.io#8029

in our documentation.

Personal PR reference: `2019-0004`