### PR TITLE
continue script when internet connection lost once

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.1
+- Fix repeat option: don't terminate if internet connection unavailable during a check
+
 ## 7.0
 - Update Hass.io CLI to 2.0.1
 

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "7.0",
+  "version": "7.1",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -126,13 +126,13 @@ function git-synchronize {
 
             # Always do a fetch to update repos
             echo "[Info] Start git fetch..."
-            git fetch "$GIT_REMOTE" || { echo "[Error] Git fetch failed"; exit 1; }
+            git fetch "$GIT_REMOTE" || { echo "[Error] Git fetch failed"; return 1; }
 
             # Prune if configured
             if [ "$GIT_PRUNE" == "true" ]
             then
               echo "[Info] Start git prune..."
-              git prune || { echo "[Error] Git prune failed"; exit 1; }
+              git prune || { echo "[Error] Git prune failed"; return 1; }
             fi
 
             # Do we switch branches?
@@ -149,11 +149,11 @@ function git-synchronize {
             case "$GIT_COMMAND" in
                 pull)
                     echo "[Info] Start git pull..."
-                    git pull || { echo "[Error] Git pull failed"; exit 1; }
+                    git pull || { echo "[Error] Git pull failed"; return 1; }
                     ;;
                 reset)
                     echo "[Info] Start git reset..."
-                    git reset --hard "$GIT_REMOTE"/"$GIT_CURRENT_BRANCH" || { echo "[Error] Git reset failed"; exit 1; }
+                    git reset --hard "$GIT_REMOTE"/"$GIT_CURRENT_BRANCH" || { echo "[Error] Git reset failed"; return 1; }
                     ;;
                 *)
                     echo "[Error] Git command is not set correctly. Should be either 'reset' or 'pull'"
@@ -217,8 +217,9 @@ cd /config || { echo "[Error] Failed to cd into /config"; exit 1; }
 while true; do
     check-ssh-key
     setup-user-password
-    git-synchronize
-    validate-config
+    git-synchronize; if [ $? -ne 1 ] ; then
+        validate-config
+    fi
      # do we repeat?
     if [ ! "$REPEAT_ACTIVE" == "true" ]; then
         exit 0

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -217,7 +217,7 @@ cd /config || { echo "[Error] Failed to cd into /config"; exit 1; }
 while true; do
     check-ssh-key
     setup-user-password
-    git-synchronize; if [ $? -ne 1 ] ; then
+    if git-synchronize ; then
         validate-config
     fi
      # do we repeat?


### PR DESCRIPTION
changed some "exit 1" to "return 1" in function git-synchronize. By this, the script should not terminate when there's no internet connection during a repeat check. I left "exit 1" for the initial, critical and config topics => script should terminate here I think.