### PR TITLE
git_pull: Enhance restart_ignore to support whole directories

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.1
+- Enhance restart_ignore to support whole directories
+
 ## 7.0
 - Update Hass.io CLI to 2.0.1
 

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "7.0",
+  "version": "7.1",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -182,11 +182,21 @@ function validate-config {
                 CHANGED_FILES=$(git diff "$OLD_COMMIT" "$NEW_COMMIT" --name-only)
                 echo "Changed Files: $CHANGED_FILES"
                 if [ -n "$RESTART_IGNORED_FILES" ]; then
-                    for file in $CHANGED_FILES; do
-                        echo "$RESTART_IGNORED_FILES" | grep -qw "${file}"
-                        if [ $? -eq 1 ] ; then
+                    for changed_file in $CHANGED_FILES; do
+                        restart_required_file=""
+                        for restart_ignored_file in $RESTART_IGNORED_FILES; do
+                            if [ -z ${restart_ignored_file#*/} ]; then
+                                # file to be ignored is a whole dir
+                                restart_required_file=$(echo "${changed_file}" | grep "^${restart_ignored_file}")
+                            else
+                                restart_required_file=$(echo "${changed_file}" | grep "^${restart_ignored_file}$")
+                            fi
+                            # break on first match
+                            if [ -n "$restart_required_file" ]; then break ; fi
+                        done
+                        if [ -z "$restart_required_file" ]; then
                             DO_RESTART="true"
-                            echo "[Info] Detected Restart Required File $file"
+                            echo "[Info] Detected restart-required file: $changed_file"
                         fi
                     done
                 else

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -185,7 +185,7 @@ function validate-config {
                     for changed_file in $CHANGED_FILES; do
                         restart_required_file=""
                         for restart_ignored_file in $RESTART_IGNORED_FILES; do
-                            if [ -z ${restart_ignored_file#*/} ]; then
+                            if [ -z "${restart_ignored_file#*/}" ]; then
                                 # file to be ignored is a whole dir
                                 restart_required_file=$(echo "${changed_file}" | grep "^${restart_ignored_file}")
                             else


### PR DESCRIPTION
Enhanced git_pull add-on's `restart_ignore` option to also support ignoring whole directories.

Useful i.e. for users like me who have their appdaemon-directory also in the HA config dir, or have split-up YAMLs.