### PR TITLE
Duck DNS alias support

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6
+- Add DNS alias option to allow pointing a CNAME at a Duck DNS subdomain
+
 ## 1.5
 - Fix bug with multible domains for Let's encrypt
 

--- a/duckdns/config.json
+++ b/duckdns/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Duck DNS",
-  "version": "1.5",
+  "version": "1.6",
   "slug": "duckdns",
   "description": "Free Dynamic DNS (DynDNS or DDNS) service with Let's Encrypt support",
   "url": "https://www.home-assistant.io/addons/duckdns/",

--- a/duckdns/config.json
+++ b/duckdns/config.json
@@ -15,6 +15,7 @@
     },
     "token": null,
     "domains": [null],
+    "aliases": [null],
     "seconds": 300
   },
   "schema": {
@@ -25,6 +26,9 @@
     },
     "token": "str",
     "domains": ["str"],
+    "aliases": [
+      {"domain": "str", "alias": "str"}
+    ],
     "seconds": "int"
   },
   "image": "homeassistant/{arch}-addon-duckdns"

--- a/duckdns/hooks.sh
+++ b/duckdns/hooks.sh
@@ -12,7 +12,7 @@ SYS_KEYFILE=$(jq --raw-output '.lets_encrypt.keyfile' $CONFIG_PATH)
 
 deploy_challenge() {
     local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}" ALIAS
-    ALIAS="$(jq --raw-output --exit-status ".aliases.\"$DOMAIN\"" $CONFIG_PATH)" || ALIAS="$DOMAIN"
+    ALIAS="$(jq --raw-output --exit-status "[.aliases[]|{(.domain):.alias}]|add.\"$DOMAIN\"" $CONFIG_PATH)" || ALIAS="$DOMAIN"
 
     # This hook is called once for every domain that needs to be
     # validated, including any alternative names you may have listed.
@@ -36,7 +36,7 @@ deploy_challenge() {
 
 clean_challenge() {
     local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}" ALIAS
-    ALIAS="$(jq --raw-output --exit-status ".aliases.\"$DOMAIN\"" $CONFIG_PATH)" || ALIAS="$DOMAIN"
+    ALIAS="$(jq --raw-output --exit-status "[.aliases[]|{(.domain):.alias}]|add.\"$DOMAIN\"" $CONFIG_PATH)" || ALIAS="$DOMAIN"
 
     # This hook is called after attempting to validate each domain,
     # whether or not validation was successful. Here you can delete

--- a/duckdns/hooks.sh
+++ b/duckdns/hooks.sh
@@ -11,7 +11,8 @@ SYS_KEYFILE=$(jq --raw-output '.lets_encrypt.keyfile' $CONFIG_PATH)
 # https://github.com/lukas2511/dehydrated/blob/master/docs/examples/hook.sh
 
 deploy_challenge() {
-    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}" ALIAS
+    ALIAS="$(jq --raw-output --exit-status ".aliases.\"$DOMAIN\"" $CONFIG_PATH)" || ALIAS="$DOMAIN"
 
     # This hook is called once for every domain that needs to be
     # validated, including any alternative names you may have listed.
@@ -30,11 +31,12 @@ deploy_challenge() {
     #   TXT record. For HTTP validation it is the value that is expected
     #   be found in the $TOKEN_FILENAME file.
 
-    curl -s "https://www.duckdns.org/update?domains=$DOMAIN&token=$SYS_TOKEN&txt=$TOKEN_VALUE"
+    curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=$TOKEN_VALUE"
 }
 
 clean_challenge() {
-    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}" ALIAS
+    ALIAS="$(jq --raw-output --exit-status ".aliases.\"$DOMAIN\"" $CONFIG_PATH)" || ALIAS="$DOMAIN"
 
     # This hook is called after attempting to validate each domain,
     # whether or not validation was successful. Here you can delete
@@ -42,7 +44,7 @@ clean_challenge() {
     #
     # The parameters are the same as for deploy_challenge.
 
-    curl -s "https://www.duckdns.org/update?domains=$DOMAIN&token=$SYS_TOKEN&txt=removed&clear=true"
+    curl -s "https://www.duckdns.org/update?domains=$ALIAS&token=$SYS_TOKEN&txt=removed&clear=true"
 }
 
 deploy_cert() {


### PR DESCRIPTION
For when you have another domain CNAME'd to the Duck DNS one.

Context: https://community.letsencrypt.org/t/dont-know-what-content-my-text-record-should-have/85439/2?u=jmorahan

The config would look like:

```
{
  "lets_encrypt": {
    "accept_terms": true,
    "certfile": "fullchain.pem",
    "keyfile": "privkey.pem"
  },
  "token": "sdfj-2131023-dslfjsd-12321",
  "domains": ["subdomain.example.com"],
  "aliases": {
    "subdomain.example.com": "example.duckdns.org"
  },
  "seconds": 300
}
```