### PR TITLE
Move custom deps to python 3.7 base

### DIFF
--- a/custom_deps/build.json
+++ b/custom_deps/build.json
@@ -1,8 +1,8 @@
 {
   "build_from": {
-    "amd64": "homeassistant/amd64-base-python:3.6",
-    "i386": "homeassistant/i386-base-python:3.6",
-    "armhf": "homeassistant/armhf-base-python:3.6",
-    "aarch64": "homeassistant/aarch64-base-python:3.6"
+    "amd64": "homeassistant/amd64-base-python:3.7",
+    "i386": "homeassistant/i386-base-python:3.7",
+    "armhf": "homeassistant/armhf-base-python:3.7",
+    "aarch64": "homeassistant/aarch64-base-python:3.7"
   }
 }


### PR DESCRIPTION
After move home-assistant to python 3.7, I think this also should be moved. When python deps are installed, they ends up in lib/python3.6/site-packages/ , so ha doesn't pick it up, if I'm correct.