### PR TITLE
Disable verbose logging for http auth plugin

### DIFF
--- a/mosquitto/CHANGELOG.md
+++ b/mosquitto/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.2
+- Enable quiet logging for http auth plugin
+
 ## 4.1
 - Update mosquitto 1.5.6
 

--- a/mosquitto/config.json
+++ b/mosquitto/config.json
@@ -20,6 +20,7 @@
   "options": {
     "logins": [],
     "anonymous": false,
+    "quiet_logs": true,
     "customize": {
       "active": false,
       "folder": "mosquitto"
@@ -32,6 +33,7 @@
         {"username": "str", "password": "str"}
     ],
     "anonymous": "bool",
+    "quiet_logs": "bool",
     "customize": {
       "active": "bool",
       "folder": "str"

--- a/mosquitto/config.json
+++ b/mosquitto/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Mosquitto broker",
-  "version": "4.1",
+  "version": "4.2",
   "slug": "mosquitto",
   "description": "An Open Source MQTT broker",
   "url": "https://home-assistant.io/addons/mosquitto/",

--- a/mosquitto/mosquitto.conf
+++ b/mosquitto/mosquitto.conf
@@ -21,7 +21,7 @@ auth_opt_http_port 8080
 auth_opt_http_getuser_uri /login
 auth_opt_http_superuser_uri /superuser
 auth_opt_http_aclcheck_uri /acl
-
+auth_opt_log_quiet true
 allow_anonymous %%ANONYMOUS%%
 
 #include_dir /share/mosquitto

--- a/mosquitto/mosquitto.conf
+++ b/mosquitto/mosquitto.conf
@@ -21,7 +21,7 @@ auth_opt_http_port 8080
 auth_opt_http_getuser_uri /login
 auth_opt_http_superuser_uri /superuser
 auth_opt_http_aclcheck_uri /acl
-auth_opt_log_quiet true
+auth_opt_log_quiet %%AUTH_QUIET_LOGS%%
 allow_anonymous %%ANONYMOUS%%
 
 #include_dir /share/mosquitto

--- a/mosquitto/run.sh
+++ b/mosquitto/run.sh
@@ -9,6 +9,7 @@ ANONYMOUS=$(jq --raw-output ".anonymous" $CONFIG_PATH)
 KEYFILE=$(jq --raw-output ".keyfile" $CONFIG_PATH)
 CERTFILE=$(jq --raw-output ".certfile" $CONFIG_PATH)
 CUSTOMIZE_ACTIVE=$(jq --raw-output ".customize.active" $CONFIG_PATH)
+AUTH_QUIET_LOGS=$(jq --raw-output ".quiet_logs" $CONFIG_PATH)
 HOMEASSISTANT_PW=
 ADDONS_PW=
 WAIT_PIDS=()
@@ -86,6 +87,7 @@ function constrain_discovery() {
 
 echo "[INFO] Setup mosquitto configuration"
 sed -i "s/%%ANONYMOUS%%/$ANONYMOUS/g" /etc/mosquitto.conf
+sed -i "s/%%AUTH_QUIET_LOGS%%/$AUTH_QUIET_LOGS/g" /etc/mosquitto.conf
 
 # Enable SSL if exists configs
 if [ -e "/ssl/$CERTFILE" ] && [ -e "/ssl/$KEYFILE" ]; then


### PR DESCRIPTION
Solves (at least in part) #523 

Avoids logging cleartext passwords when using the http auth plugin.
