### PR TITLE
configurator: Add git SSH support

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.5
+
+- Add support for SSH keys
+
 ## 3.4
 
 - Adds documentation to add-on repository

--- a/configurator/Dockerfile
+++ b/configurator/Dockerfile
@@ -5,7 +5,7 @@ FROM $BUILD_FROM
 ARG CONFIGURATOR_VERSION
 ARG HASSIO_AUTH_VERSION
 RUN apk add --no-cache \
-    git nginx nginx-mod-http-lua lua-resty-http \
+    git nginx nginx-mod-http-lua lua-resty-http openssh-client \
     && git clone --depth 1 -b ${HASSIO_AUTH_VERSION} \
       "https://github.com/home-assistant/hassio-auth" \
     && cp -f hassio-auth/nginx-frontend/ha-auth.lua /etc/nginx/ \

--- a/configurator/README.md
+++ b/configurator/README.md
@@ -57,7 +57,8 @@ Add-on configuration:
   "enforce_basepath": false,
   "ignore_pattern": [
     "__pycache__"
-  ]
+  ],
+  "ssh_keys": []
 }
 ```
 
@@ -75,6 +76,10 @@ If set to `true`, access is limited to files within the `/config` directory.
 
 This option allows you to hide files and folders from the file browser tree.
 By default, it hides the `__pycache__` folders.
+
+### Option: `ssh_keys` (required)
+
+A list of filenames containing SSH private keys. These can be used to allow for access to remote git repositories.
 
 ## Known issues and limitations
 

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -33,14 +33,16 @@
     "enforce_basepath": false,
     "ignore_pattern": [
       "__pycache__"
-    ]
+    ],
+    "ssh_keys": []
   },
   "schema": {
     "dirsfirst": "bool",
     "enforce_basepath": "bool",
     "ignore_pattern": [
       "str"
-    ]
+    ],
+    "ssh_keys": ["str"]
   },
   "image": "homeassistant/{arch}-addon-configurator"
 }

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Configurator",
-  "version": "3.4",
+  "version": "3.5",
   "slug": "configurator",
   "description": "Browser-based configuration file editor for Home Assistant",
   "url": "https://home-assistant.io/addons/configurator",

--- a/configurator/data/run.sh
+++ b/configurator/data/run.sh
@@ -6,6 +6,28 @@ ENFORCE_BASEPATH=$(bashio::config 'enforce_basepath')
 IGNORE_PATTERN="$(bashio::jq "/data/options.json" ".ignore_pattern")"
 WAIT_PIDS=()
 
+# If any SSH key files are defined in the configuration options, add them for use by git
+if bashio::config.has_value "ssh_keys"; then
+  # Start the SSH agent
+  bashio::log.info "Starting SSH agent"
+  eval "$(ssh-agent -s)"
+
+  # Add the keys defined in the configuration options
+  while read -r filename; do
+    if bashio::fs.file_exists "$filename"; then
+      bashio::log.info "Adding SSH private key file \"$filename\""
+      ssh-add -q "$filename"
+    else
+      bashio::log.error "SSH key file \"$filename\" not found"
+    fi
+  done <<< "$(bashio::config 'ssh_keys')"
+
+  # Disable strict host key checking
+  mkdir -p ~/.ssh
+  echo "Host *
+    StrictHostKeyChecking no" > ~/.ssh/config
+fi
+
 # Setup and run Frontend
 sed -i "s/%%PORT%%/8080/g" /etc/nginx/nginx-ingress.conf
 sed -i "s/%%PORT_INGRESS%%/8099/g" /etc/nginx/nginx-ingress.conf


### PR DESCRIPTION
Add an option to the Configurator add-on to define an SSH key for use by git. Based on the git_pull add-on.