### PR TITLE
check_config: Additional information in log output to avoid confusion

### DIFF
--- a/check_config/run.sh
+++ b/check_config/run.sh
@@ -19,7 +19,7 @@ if ! PIP_OUTPUT="$(pip3 install --find-links "${WHEELS_LINKS}" "${CMD}")"; then
     bashio::exit.nok
 fi
 INSTALLED_VERSION="$(pip freeze | grep homeassistant)"
-bashio::log.info "Installed Home Assistant ${INSTALLED_VERSION##*=}."
+bashio::log.info "Installed Home Assistant ${INSTALLED_VERSION##*=} in this add-on."
 
 # Making an temporary copy of your configuration
 bashio::log.info "Making a copy of your configuration for checking..."

--- a/check_config/run.sh
+++ b/check_config/run.sh
@@ -19,7 +19,8 @@ if ! PIP_OUTPUT="$(pip3 install --find-links "${WHEELS_LINKS}" "${CMD}")"; then
     bashio::exit.nok
 fi
 INSTALLED_VERSION="$(pip freeze | grep homeassistant)"
-bashio::log.info "Installed Home Assistant ${INSTALLED_VERSION##*=} in this add-on."
+bashio::log.info "Installed Home Assistant ${INSTALLED_VERSION##*=}"
+bashio::log.info "Don't worry, this temporary installation is not overwriting your current one."
 
 # Making an temporary copy of your configuration
 bashio::log.info "Making a copy of your configuration for checking..."


### PR DESCRIPTION
Updated log file to say that the new versions was installed ONLY to this add-on.

This is because previously new users were fearing that it installed a new version to their production machine due to the log message; this PR is to improve the log to indicate that the new version was installed *only* to this add-on.