### PR TITLE
dhcp_server: Fixes crash when using FQDN as domain

### DIFF
--- a/dhcp_server/CHANGELOG.md
+++ b/dhcp_server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2
+
+- Fixes crash when using FQDN as domain
+
 ## 1.1
 
 - Rewrite add-on onto Bashio

--- a/dhcp_server/config.json
+++ b/dhcp_server/config.json
@@ -1,6 +1,6 @@
 {
   "name": "DHCP server",
-  "version": "1.1",
+  "version": "1.2",
   "slug": "dhcp_server",
   "description": "A simple DHCP server",
   "url": "https://home-assistant.io/addons/dhcp_server/",

--- a/dhcp_server/run.sh
+++ b/dhcp_server/run.sh
@@ -13,7 +13,7 @@ DOMAIN=$(bashio::config 'domain')
 MAX_LEASE=$(bashio::config 'max_lease')
 
 {
-    echo "option domain-name ${DOMAIN};"
+    echo "option domain-name \"${DOMAIN}\";"
     echo "option domain-name-servers ${DNS};";
     echo "default-lease-time ${DEFAULT_LEASE};"
     echo "max-lease-time ${MAX_LEASE};"


### PR DESCRIPTION
Fixes a crash when using an FQDN as a domain, e.g., `home.local` instead of just `local` or `home.