### PR TITLE
ssh: Fixes crash when using authorized keys

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.6
+
+- Fixes crash when using authorized keys
+
 ## 5.5
 
 - Rewrite add-on onto Bashio

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache \
     mosquitto-clients \
     nano \
     openssh \
+    pwgen \
     tmux \
     vim
 

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "SSH server",
-  "version": "5.5",
+  "version": "5.6",
   "slug": "ssh",
   "description": "Allows connections over SSH",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",

--- a/ssh/run.sh
+++ b/ssh/run.sh
@@ -16,7 +16,7 @@ if bashio::config.has_value 'authorized_keys'; then
     sed -i s/#PasswordAuthentication.*/PasswordAuthentication\ no/ /etc/ssh/sshd_config
 
     # Unlock account
-    PASSWORD="$(strings /dev/urandom | tr -dc _A-Z-a-z-0-9 | head -c32)"
+    PASSWORD="$(pwgen -s 64 1)"
     echo "root:${PASSWORD}" | chpasswd 2&> /dev/null
 elif bashio::config.has_value 'password'; then
     bashio::log.info "Setup password login"


### PR DESCRIPTION
Fixes crash in random password generator when using authorized keys.
The crash is caused by a pipefail. Added `pwgen` to replace the current logic.

Fixes #599