### PR TITLE
Bump Deconz to 2.05.65

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4
+
+- Bump deCONZ to 2.05.65
+
 ## 2.3
 
 - Rewrite of README

--- a/deconz/build.json
+++ b/deconz/build.json
@@ -4,6 +4,6 @@
     "armhf": "homeassistant/armhf-base-raspbian:stretch"
   },
   "args": {
-    "DECONZ_VERSION": "2.05.64"
+    "DECONZ_VERSION": "2.05.65"
   }
 }

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "2.3",
+  "version": "2.4",
   "slug": "deconz",
   "description": "Control a ZigBee network with Conbee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf"],


### PR DESCRIPTION
Bump deconz to [latest version](https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/V2_05_65) 