### PR TITLE
Error correction deconz installation instructions

### DIFF
--- a/deconz/README.md
+++ b/deconz/README.md
@@ -16,7 +16,7 @@ resulting in a smooth update.
 The installation of this add-on is straightforward and easy to do.
 
 1. Navigate in your Home Assistant frontend to **Hass.io** -> **Add-on Store**.
-2. Find the "Check Home Assistant configuration" add-on and click it.
+2. Find the "deCONZ" add-on and click it.
 3. Click on the "INSTALL" button.
 
 ## How to use


### PR DESCRIPTION
Corrected an error in the README file for deCONZ. The installation instrcutions were referring to the wrong addon.