### PR TITLE
deconz: Bumps version to 2.5

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5
+
+- Corrects error in installation instructions steps
+
 ## 2.4
 
 - Bump deCONZ to 2.05.65

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "2.4",
+  "version": "2.5",
   "slug": "deconz",
   "description": "Control a ZigBee network with Conbee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf"],


### PR DESCRIPTION
## Release 2.5.

- Corrects error in installation instructions steps

See PR: #605 