### PR TITLE
⬆️ Deconz: bump to 2.05.66

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.7
+
+- Bump deCONZ to 2.05.66
+
 ## 2.6
 
 - Adding missing dependencies of deconz

--- a/deconz/build.json
+++ b/deconz/build.json
@@ -4,6 +4,6 @@
     "armhf": "homeassistant/armhf-base-raspbian:stretch"
   },
   "args": {
-    "DECONZ_VERSION": "2.05.65"
+    "DECONZ_VERSION": "2.05.66"
   }
 }

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "2.6",
+  "version": "2.7",
   "slug": "deconz",
   "description": "Control a ZigBee network with Conbee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf"],


### PR DESCRIPTION
Bump deconz to [latest version](https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/V2_05_66)