### PR TITLE
deconz: Adds VNC & debug controls

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0
+
+- Adds support for accessing deCONZ via VNC
+- Adds debug output control options
+
 ## 2.7
 
 - Bump deCONZ to 2.05.66

--- a/deconz/Dockerfile
+++ b/deconz/Dockerfile
@@ -9,10 +9,9 @@ ARG BUILD_ARCH
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
+        iproute2 \
+        iputils-ping \
         kmod \
-        lsof \
-        tzdata \
-        netcat \
         libcap2-bin \
         libqt5core5a \
         libqt5gui5 \
@@ -21,10 +20,16 @@ RUN apt-get update \
         libqt5sql5 \
         libqt5websockets5 \
         libqt5widgets5 \
+        lsof \
+        netcat \
         sqlite3 \
-        iputils-ping \
-        iproute2 \
+        tigervnc-common \
+        tigervnc-standalone-server \
+        tzdata \
         wget \
+        wmii \
+        xfonts-base \
+        xfonts-scalable \
     && rm -rf /var/lib/apt/lists/* \
     && if [ "${BUILD_ARCH}" = "armhf" ] || [ "${BUILD_ARCH}" = "aarch64" ]; \
         then \

--- a/deconz/Dockerfile
+++ b/deconz/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update \
         sqlite3 \
         tigervnc-common \
         tigervnc-standalone-server \
-        tzdata \
         wget \
         wmii \
         xfonts-base \

--- a/deconz/README.md
+++ b/deconz/README.md
@@ -71,6 +71,50 @@ Phoscon WebUI, then restore that config after installing/reinstalling.
 
 However, your ZigBee devices will remain paired to your ConBee or RaspBee hardware.
 
+## Accessing the deCONZ application and viewing the mesh via VNC
+
+The add-on allows you to access the underlying deCONZ application running on
+a remote desktop via VNC. It allows you to view the ZigBee mesh (which can
+be really helpful when debugging network issues), but also gives you access
+to tons of advanced features.
+
+To enable it:
+
+- Set a port number for VNC in the "Network" configuration section of the
+  add-on and hit "SAVE". Advised is to use port 5900, but any other port above
+  5900 works as well.
+- Set a VNC password in the add-on configuration and hit "SAVE".
+- Restart the add-on.
+
+To access it you need a [VNC Viewer][vnc-viewer] application.
+
+If you are using macOS, you are in luck, since VNC is built-in. Open the
+spotlight search and enter: `vnc://hassio.local:5900`
+
+## Advanced debug output control
+
+Hidden controls are added to the add-on to allow control over the debug
+output of deCONZ. The following options are hidden, but can be added to
+the add-on configuration:
+
+- `dbg_info`
+- `dbg_aps`
+- `dbg_otau`
+- `dbg_zcl`
+- `dbg_zdp`
+
+These options require a number that represents the log level.
+
+Example add-on config with `dbg_aps` enabled on log level 1:
+
+```json
+{
+  "device": "/dev/ttyUSB0",
+  "vnc_password": "",
+  "dbg_aps": 1
+}
+```
+
 ## Configuration
 
 Add-on configuration:
@@ -120,4 +164,4 @@ In case you've found an bug, please [open an issue on our GitHub][issue].
 [i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/home-assistant/hassio-addons/issues
 [reddit]: https://reddit.com/r/homeassistant
-[repository]: https://github.com/hassio-addons/repository
+[vnc-viewer]: https://bintray.com/tigervnc/stable/tigervnc/

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "2.7",
+  "version": "3.0",
   "slug": "deconz",
   "description": "Control a ZigBee network with Conbee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf"],
@@ -12,10 +12,12 @@
   "discovery": ["deconz"],
   "ports": {
     "80/tcp": 40850,
+    "5900/tcp": null,
     "8080/tcp": 40860
   },
   "ports_description": {
     "80/tcp": "deCONZ API backend",
+    "5900/tcp": "deCONZ graphical desktop via VNC",
     "8080/tcp": "deCONZ WebSocket Server"
   },
   "host_network": true,
@@ -32,10 +34,17 @@
     "/dev/mem:/dev/mem:rw"
   ],
   "options": {
-   "device": null
+   "device": null,
+   "vnc_password": ""
   },
   "schema": {
-    "device": "str"
+    "device": "str",
+    "vnc_password": "str",
+    "dbg_aps": "int?",
+    "dbg_info": "int?",
+    "dbg_otau": "int?",
+    "dbg_zcl": "int?",
+    "dbg_zdp": "int?"
   },
   "image": "homeassistant/{arch}-addon-deconz"
 }

--- a/deconz/data/run.sh
+++ b/deconz/data/run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bashio
 set -e
 
+# Ensure otau folder exists
 mkdir -p "/data/otau"
 
 # shellcheck disable=SC1091
@@ -8,26 +9,72 @@ mkdir -p "/data/otau"
 
 WAIT_PIDS=()
 
+# Default QTinfo platform
+PLATFORM="minimal"
+
 # Load config
 DECONZ_DEVICE=$(bashio::config 'device')
 API_PORT=$(bashio::addon.port 80)
+VNC_PORT=$(bashio::addon.port 5900)
+VNC_PASSWORD=$(bashio::config 'vnc_password')
 WEBSOCKET_PORT=$(bashio::addon.port 8080)
 
+# Load debug values
+bashio::config.has_value 'dbg_info' \
+    && DBG_INFO="$(bashio::config 'dbg_info')" || DBG_INFO=1
+bashio::config.has_value 'dbg_aps' \
+    && DBG_APS="$(bashio::config 'dbg_aps')" || DBG_APS=0
+bashio::config.has_value 'dbg_otau' \
+    && DBG_OTAU="$(bashio::config 'dbg_otau')" || DBG_OTAU=0
+bashio::config.has_value 'dbg_zcl' \
+    && DBG_ZCL="$(bashio::config 'dbg_zcl')" || DBG_ZCL=0
+bashio::config.true 'dbg_zdp' \
+    && DBG_ZDP="$(bashio::config 'dbg_zdp')" || DBG_ZDP=0
+
 # Check if port is available
-if [ -z "${API_PORT}" ] || [ -z "${WEBSOCKET_PORT}" ]; then
-    bashio::exit.nok "You need set API/Websocket port!"
+if bashio::var.is_empty "${API_PORT}" \
+    || bashio::var.is_empty "${WEBSOCKET_PORT}";
+then
+    bashio::exit.nok "You need set API and Websocket port!"
 fi
 
-# Start Gateway
-bashio::log.info "Start deCONZ gateway"
+# Check if VNC is enabled
+if bashio::var.has_value "${VNC_PORT}"; then
+    if [[ "${VNC_PORT}" -lt 5900 ]]; then
+        bashio::exit.nok "VNC requires the port number to be set to 5900 or higher!"
+    fi
+
+    TMP_FOLDER=$(mktemp -d)
+    export XDG_RUNTIME_DIR="${TMP_FOLDER}"
+    export DISPLAY=":$((VNC_PORT-5900))"
+    PLATFORM="xcb"
+
+    # Require password when VNC is enabled
+    if ! bashio::config.has_value 'vnc_password'; then
+        bashio::exit.nok "VNC has been enabled, but no password has been set!"
+    fi
+
+    bashio::log.info "Starting VNC server..."
+    echo "${VNC_PASSWORD}" | tigervncpasswd -f > /root/.vncpasswd
+    tigervncserver \
+        -geometry 1920x1080 \
+        -depth 16 \
+        -localhost no \
+        -PasswordFile /root/.vncpasswd \
+        "${DISPLAY}" \
+        &> /dev/null
+fi
+
+# Start deCONZ
+bashio::log.info "Starting the deCONZ gateway..."
 deCONZ \
-    -platform minimal \
+    -platform "${PLATFORM}" \
     --auto-connect=1 \
-    --dbg-info=1 \
-    --dbg-aps=0 \
-    --dbg-zcl=0 \
-    --dbg-zdp=0 \
-    --dbg-otau=0 \
+    --dbg-info="${DBG_INFO}" \
+    --dbg-aps="${DBG_APS}" \
+    --dbg-otau="${DBG_OTAU}" \
+    --dbg-zcl="${DBG_ZCL}" \
+    --dbg-zdp="${DBG_ZDP}" \
     --http-port="${API_PORT}" \
     --ws-port="${WEBSOCKET_PORT}" \
     --upnp=0 \
@@ -35,12 +82,12 @@ deCONZ \
 WAIT_PIDS+=($!)
 
 # Start OTA updates for deCONZ
-bashio::log.info "Run deCONZ OTA updater"
+bashio::log.info "Running the deCONZ OTA updater..."
 deCONZ-otau-dl.sh &> /dev/null &
 WAIT_PIDS+=($!)
 
 # Start OTA updates for IKEA
-bashio::log.info "Run IKEA OTA updater"
+bashio::log.info "Running the IKEA OTA updater..."
 ika-otau-dl.sh &> /dev/null &
 WAIT_PIDS+=($!)
 
@@ -55,9 +102,9 @@ function stop_addon() {
 trap "stop_addon" SIGTERM SIGHUP
 
 # Start Hass.io discovery
-bashio::log.info "Run Hass.io discovery task"
+bashio::log.info "Running Hass.io discovery task..."
 hassio_discovery
 
 # Wait until all is done
-bashio::log.info "deCONZ is setup and running"
+bashio::log.info "deCONZ is set up and running!"
 wait "${WAIT_PIDS[@]}"

--- a/deconz/data/run.sh
+++ b/deconz/data/run.sh
@@ -9,7 +9,7 @@ mkdir -p "/data/otau"
 
 WAIT_PIDS=()
 
-# Default QTinfo platform
+# Default QT platform
 PLATFORM="minimal"
 
 # Load config
@@ -28,7 +28,7 @@ bashio::config.has_value 'dbg_otau' \
     && DBG_OTAU="$(bashio::config 'dbg_otau')" || DBG_OTAU=0
 bashio::config.has_value 'dbg_zcl' \
     && DBG_ZCL="$(bashio::config 'dbg_zcl')" || DBG_ZCL=0
-bashio::config.true 'dbg_zdp' \
+bashio::config.has_value 'dbg_zdp' \
     && DBG_ZDP="$(bashio::config 'dbg_zdp')" || DBG_ZDP=0
 
 # Check if port is available


### PR DESCRIPTION
## 3.0

- Adds support for accessing deCONZ via VNC
- Adds debug output control options

Notes:
- `vnc_password` is an empty string by default, since requiring a password for a disabled feature looked a bit weird. The startup does, however, ensure there is a password set.
- The debug features are left out of the configuration by default since I expect them not to be used by a "regular" user.