### PR TITLE
deconz: 3.1: VNC Port check & desktop name + firmware upgrade docs

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1
+
+- Improves VNC desktop name
+- Adds check if VNC port is free to use
+- Documents firmware upgrade process and caveats
+
 ## 3.0
 
 - Adds support for accessing deCONZ via VNC

--- a/deconz/README.md
+++ b/deconz/README.md
@@ -84,6 +84,18 @@ To access it you need a [VNC Viewer][vnc-viewer] application.
 If you are using macOS, you are in luck, since VNC is built-in. Open the
 spotlight search and enter: `vnc://hassio.local:5900`
 
+## Upgrading RaspBee and ConBee firmware
+
+This add-on allows you to upgrade your firmware straight from the Phoscon
+web interface with ease.
+
+Go to "Settings -> Gateway" and click the upgrade button.
+
+However, some USB sticks (like the Aeotec Z-Wave sticks), can interfere with
+the upgrade process, causing the firmware upgrade to fail silently. If you end
+up with the same firmware version as before you started the upgrade, consider
+unplugging the other sticks and try again.
+
 ## Advanced debug output control
 
 Hidden controls are added to the add-on to allow control over the debug

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,8 +1,8 @@
 {
   "name": "deCONZ",
-  "version": "3.0",
+  "version": "3.1",
   "slug": "deconz",
-  "description": "Control a ZigBee network with Conbee or RaspBee by Dresden Elektronik",
+  "description": "Control a ZigBee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf"],
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/deconz",
   "startup": "system",

--- a/deconz/data/run.sh
+++ b/deconz/data/run.sh
@@ -57,6 +57,7 @@ if bashio::var.has_value "${VNC_PORT}"; then
     bashio::log.info "Starting VNC server..."
     echo "${VNC_PASSWORD}" | tigervncpasswd -f > /root/.vncpasswd
     tigervncserver \
+        -name "Hass.io - deCONZ" \
         -geometry 1920x1080 \
         -depth 16 \
         -localhost no \

--- a/deconz/data/run.sh
+++ b/deconz/data/run.sh
@@ -44,6 +44,12 @@ if bashio::var.has_value "${VNC_PORT}"; then
         bashio::exit.nok "VNC requires the port number to be set to 5900 or higher!"
     fi
 
+    # Check if configured VNC port is free
+    if nc -z 127.0.0.1 "${VNC_PORT}"; then
+        bashio::log.fatal "VNC port ${VNC_PORT} is already in use!"
+        bashio::exit.nok "Please change the port number"
+    fi
+
     TMP_FOLDER=$(mktemp -d)
     export XDG_RUNTIME_DIR="${TMP_FOLDER}"
     export DISPLAY=":$((VNC_PORT-5900))"


### PR DESCRIPTION
## 3.1

- Improves VNC desktop name
- Adds check if VNC port is free to use
- Documents firmware upgrade process and caveats
