### PR TITLE
ssh: Upgrades Hassio CLI to v2.3.0

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.1
+
+- Update Hass.io CLI to 2.3.0
+
 ## 6.0
 
 - Update and pin base image to Alpine 3.10

--- a/ssh/build.json
+++ b/ssh/build.json
@@ -7,6 +7,6 @@
     "aarch64": "homeassistant/aarch64-base:3.10"
   },
   "args": {
-    "CLI_VERSION": "2.2.0"
+    "CLI_VERSION": "2.3.0"
   }
 }

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "SSH server",
-  "version": "6.0",
+  "version": "6.1",
   "slug": "ssh",
   "description": "Allows connections over SSH",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",


### PR DESCRIPTION
Upgrades Hass.io CLI to v2.3.0

https://github.com/home-assistant/hassio-cli/releases/tag/2.3.0