### PR TITLE
git_pull: Upgrades Hassio CLI to v2.3.0

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.4
+
+- Update Hass.io CLI to 2.3.0
+
 ## 7.3
 
 - Update Hass.io CLI to 2.2.0

--- a/git_pull/build.json
+++ b/git_pull/build.json
@@ -1,5 +1,5 @@
 {
   "args": {
-    "CLI_VERSION": "2.2.0"
+    "CLI_VERSION": "2.3.0"
   }
 }

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "7.3",
+  "version": "7.4",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",


### PR DESCRIPTION
Upgrades the Hass.io CLI to v2.3.0

https://github.com/home-assistant/hassio-cli/releases/tag/2.3.0