### PR TITLE
Bump deCONZ 2.05.69 & wiringPi 2.52

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.6
 
 - Bump deCONZ to 2.05.69
+- Update wiringPi to latest (2.52)
 
 ## 3.5
 

--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6
+
+- Bump deCONZ to 2.05.69
+
 ## 3.5
 
 - Add support for native aarch64

--- a/deconz/Dockerfile
+++ b/deconz/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && if [ "${BUILD_ARCH}" = "armhf" ]; \
         then \
-            curl -q -L -o /wiringpi.deb https://unicorn.drogon.net/wiringpi-2.46-1.deb \
+            curl -q -L -o /wiringpi.deb https://project-downloads.drogon.net/wiringpi-latest.deb \
             && dpkg -i /wiringpi.deb \
             && rm -rf /wiringpi.deb; \
         fi

--- a/deconz/build.json
+++ b/deconz/build.json
@@ -5,6 +5,6 @@
     "aarch64": "homeassistant/aarch64-base-debian:stretch"
   },
   "args": {
-    "DECONZ_VERSION": "2.05.67"
+    "DECONZ_VERSION": "2.05.69"
   }
 }

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "3.5",
+  "version": "3.6",
   "slug": "deconz",
   "description": "Control a ZigBee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],


### PR DESCRIPTION
## 3.6

- Bump deCONZ to 2.05.69
  <https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/V2_05_69>
- Update wiringPi to latest (2.52)
  <http://wiringpi.com/wiringpi-updated-to-2-52-for-the-raspberry-pi-4b/>
