### PR TITLE
Update nginx.conf fix nginx: [warn] the "ssl" directive is deprecated

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3
+
+- Fix issue with `nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead` in ngnix.conf:45
+
 ## 2.2
 
 - Fix issue with `homeassistant` connection

--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.3
 
-- Fix issue with `nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead` in ngnix.conf:45
+- Fix issue with nginx warning for ssl directive
 
 ## 2.2
 

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "NGINX Home Assistant SSL proxy",
-  "version": "2.2",
+  "version": "2.3",
   "slug": "nginx_proxy",
   "description": "An SSL/TLS proxy",
   "url": "https://home-assistant.io/addons/nginx_proxy/",

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -40,9 +40,8 @@ http {
         # dhparams file
         ssl_dhparam /data/dhparams.pem;
 
-        listen [::]:443 http2;
+        listen [::]:443 ssl http2;
         %%HSTS%%
-        ssl on;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
         ssl_prefer_server_ciphers on;


### PR DESCRIPTION
Fix for the nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in ngnix.conf:45 appearing in log