### PR TITLE
Added an optional Cloudflare mechanism for real visitor ip

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4
+
+- Added cloudflare mechanism using auto-generated ipv4/ipv6 list for real visitor ip
+
 ## 2.3
 
 - Fix issue with nginx warning for ssl directive

--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4
 
-- Added cloudflare mechanism using auto-generated ipv4/ipv6 list for real visitor ip
+- Added Cloudflare mechanism for creating auto-generated ipv4/ipv6 list for real visitor ip
 
 ## 2.3
 

--- a/nginx_proxy/Dockerfile
+++ b/nginx_proxy/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM
 FROM $BUILD_FROM
 
 # Setup base
-RUN apk add --no-cache nginx openssl
+RUN apk add --no-cache nginx openssl curl
 
 # Copy data
 COPY data/run.sh /

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -18,8 +18,7 @@
     "keyfile": "privkey.pem",
     "hsts": "max-age=31536000; includeSubDomains",
     "cloudflare": {
-      "enable": false,
-      "real_ip_header": "CF-Connecting-IP"
+      "enable": false
     },
     "customize": {
       "active": false,
@@ -33,8 +32,7 @@
     "keyfile": "str",
     "hsts": "str",
     "cloudflare": {
-      "enable": "bool",
-      "real_ip_header": "str"
+      "enable": "bool"
     },
     "customize": {
       "active": "bool",

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "NGINX Home Assistant SSL proxy",
-  "version": "2.3",
+  "version": "2.4",
   "slug": "nginx_proxy",
   "description": "An SSL/TLS proxy",
   "url": "https://home-assistant.io/addons/nginx_proxy/",

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -31,9 +31,7 @@
     "certfile": "str",
     "keyfile": "str",
     "hsts": "str",
-    "cloudflare": {
-      "enable": "bool"
-    },
+    "cloudflare": "bool",
     "customize": {
       "active": "bool",
       "default": "str",

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -17,6 +17,10 @@
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "hsts": "max-age=31536000; includeSubDomains",
+    "cloudflare": {
+      "enable": false,
+      "real_ip_header": "CF-Connecting-IP"
+    },
     "customize": {
       "active": false,
       "default": "nginx_proxy_default*.conf",
@@ -28,6 +32,10 @@
     "certfile": "str",
     "keyfile": "str",
     "hsts": "str",
+    "cloudflare": {
+      "enable": "bool",
+      "real_ip_header": "str"
+    },
     "customize": {
       "active": "bool",
       "default": "str",

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -17,9 +17,7 @@
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "hsts": "max-age=31536000; includeSubDomains",
-    "cloudflare": {
-      "enable": false
-    },
+    "cloudflare": false,
     "customize": {
       "active": false,
       "default": "nginx_proxy_default*.conf",

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -14,6 +14,8 @@ http {
     
     server_names_hash_bucket_size 64;
 
+	#include /share/nginx_proxy_cloudflare.conf;
+	
     server {
         server_name _;
         listen [::]:80 default_server ipv6only=off;

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -14,7 +14,7 @@ http {
     
     server_names_hash_bucket_size 64;
 
-	#include /share/nginx_proxy_cloudflare.conf;
+#include /share/nginx_proxy_cloudflare.conf;
 	
     server {
         server_name _;

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -13,8 +13,8 @@ http {
     }
     
     server_names_hash_bucket_size 64;
-
-#include /share/nginx_proxy_cloudflare.conf;
+	
+	#include /share/nginx_proxy_cloudflare.conf;
 	
     server {
         server_name _;

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -14,7 +14,7 @@ http {
     
     server_names_hash_bucket_size 64;
 	
-    #include /data/nginx_cloudflare.conf;
+    #include /data/cloudflare.conf;
 	
     server {
         server_name _;

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -14,7 +14,7 @@ http {
     
     server_names_hash_bucket_size 64;
 	
-	#include /share/nginx_proxy_cloudflare.conf;
+    #include /data/nginx_cloudflare.conf;
 	
     server {
         server_name _;

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -15,7 +15,6 @@ CERTFILE=$(jq --raw-output ".certfile" $CONFIG_PATH)
 HSTS=$(jq --raw-output ".hsts // empty" $CONFIG_PATH)
 CUSTOMIZE_ACTIVE=$(jq --raw-output ".customize.active" $CONFIG_PATH)
 CLOUDFLARE_ENABLE=$(jq --raw-output ".cloudflare.enable" $CONFIG_PATH)
-CLOUDFLARE_REAL_IP_HEADER=$(jq --raw-output ".cloudflare.real_ip_header" $CONFIG_PATH)
 
 # Generate dhparams
 if [ ! -f "$DHPARAMS_PATH" ]; then
@@ -48,7 +47,7 @@ if [ "$CLOUDFLARE_ENABLE" == "true" ]; then
         done
         
         echo "" >> $CLOUDFLARE_CONF;
-        echo "real_ip_header ${CLOUDFLARE_REAL_IP_HEADER};" >> $CLOUDFLARE_CONF;
+        echo "real_ip_header CF-Connecting-IP;" >> $CLOUDFLARE_CONF;
     fi
 fi
 

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -37,14 +37,14 @@ if [ "$CLOUDFLARE_ENABLE" == "true" ]; then
         echo "" >> $CLOUDFLARE_CONF;
 
         echo "# - IPv4" >> $CLOUDFLARE_CONF;
-        for i in `curl https://www.cloudflare.com/ips-v4`; do
-            echo "set_real_ip_from $i;" >> $CLOUDFLARE_CONF;
+        for i in $(curl https://www.cloudflare.com/ips-v4); do
+            echo "set_real_ip_from ${i};" >> $CLOUDFLARE_CONF;
         done
         
         echo "" >> $CLOUDFLARE_CONF;
         echo "# - IPv6" >> $CLOUDFLARE_CONF;
-        for i in `curl https://www.cloudflare.com/ips-v6`; do
-            echo "set_real_ip_from $i;" >> $CLOUDFLARE_CONF;
+        for i in $(curl https://www.cloudflare.com/ips-v6); do
+            echo "set_real_ip_from ${i};" >> $CLOUDFLARE_CONF;
         done
         
         echo "" >> $CLOUDFLARE_CONF;

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -27,7 +27,7 @@ if [ ! -f "$SNAKEOIL_CERT" ]; then
     openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout $SNAKEOIL_KEY -out $SNAKEOIL_CERT -subj '/CN=localhost'
 fi
 
-# Generate nginx_cloudflare.conf
+# Generate cloudflare.conf
 if [ ! -f "$CLOUDFLARE_CONF" ]; then
    echo "[INFO] Creating 'cloudflare.conf' for set_real_ip_from..."
    echo "# Cloudflare IP addresses" > $CLOUDFLARE_CONF;

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -14,6 +14,7 @@ KEYFILE=$(jq --raw-output ".keyfile" $CONFIG_PATH)
 CERTFILE=$(jq --raw-output ".certfile" $CONFIG_PATH)
 HSTS=$(jq --raw-output ".hsts // empty" $CONFIG_PATH)
 CUSTOMIZE_ACTIVE=$(jq --raw-output ".customize.active" $CONFIG_PATH)
+CLOUDFLARE_ACTIVE=$(jq --raw-output ".cloudflare.active" $CONFIG_PATH)
 
 # Generate dhparams
 if [ ! -f "$DHPARAMS_PATH" ]; then
@@ -28,7 +29,7 @@ fi
 
 # Generate nginx_cloudflare.conf
 if [ ! -f "$CLOUDFLARE_CONF" ]; then
-   echo "[INFO] Creating 'nginx_cloudflare.conf' for set_real_ip_from..."
+   echo "[INFO] Creating 'cloudflare.conf' for set_real_ip_from..."
    echo "# Cloudflare IP addresses" > $CLOUDFLARE_CONF;
    echo "" >> $CLOUDFLARE_CONF;
 

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -38,7 +38,7 @@ if [ ! -f "$CLOUDFLARE_CONF" ]; then
    done
 
    echo "" >> $CLOUDFLARE_CONF;
-   echo "# - IPv6" >> cloudflare;
+   echo "# - IPv6" >> $CLOUDFLARE_CONF;
    for i in `curl https://www.cloudflare.com/ips-v6`; do
        echo "set_real_ip_from $i;" >> $CLOUDFLARE_CONF;
     done

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -14,7 +14,8 @@ KEYFILE=$(jq --raw-output ".keyfile" $CONFIG_PATH)
 CERTFILE=$(jq --raw-output ".certfile" $CONFIG_PATH)
 HSTS=$(jq --raw-output ".hsts // empty" $CONFIG_PATH)
 CUSTOMIZE_ACTIVE=$(jq --raw-output ".customize.active" $CONFIG_PATH)
-CLOUDFLARE_ACTIVE=$(jq --raw-output ".cloudflare.active" $CONFIG_PATH)
+CLOUDFLARE_ENABLED=$(jq --raw-output ".cloudflare.enabled" $CONFIG_PATH)
+CLOUDFLARE_REAL_IP_HEADER=$(jq --raw-output ".cloudflare.real_ip_header" $CONFIG_PATH)
 
 # Generate dhparams
 if [ ! -f "$DHPARAMS_PATH" ]; then
@@ -27,25 +28,27 @@ if [ ! -f "$SNAKEOIL_CERT" ]; then
     openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout $SNAKEOIL_KEY -out $SNAKEOIL_CERT -subj '/CN=localhost'
 fi
 
-# Generate cloudflare.conf
-if [ ! -f "$CLOUDFLARE_CONF" ]; then
-   echo "[INFO] Creating 'cloudflare.conf' for real visitor IP address..."
-   echo "# Cloudflare IP addresses" > $CLOUDFLARE_CONF;
-   echo "" >> $CLOUDFLARE_CONF;
+if [ "$CLOUDFLARE_ENABLED" == "true" ]; then
+    # Generate cloudflare.conf
+    if [ ! -f "$CLOUDFLARE_CONF" ]; then
+        echo "[INFO] Creating 'cloudflare.conf' for real visitor IP address..."
+        echo "# Cloudflare IP addresses" > $CLOUDFLARE_CONF;
+        echo "" >> $CLOUDFLARE_CONF;
 
-   echo "# - IPv4" >> $CLOUDFLARE_CONF;
-   for i in `curl https://www.cloudflare.com/ips-v4`; do
-       echo "set_real_ip_from $i;" >> $CLOUDFLARE_CONF;
-   done
-
-   echo "" >> $CLOUDFLARE_CONF;
-   echo "# - IPv6" >> $CLOUDFLARE_CONF;
-   for i in `curl https://www.cloudflare.com/ips-v6`; do
-       echo "set_real_ip_from $i;" >> $CLOUDFLARE_CONF;
-    done
-    
-    echo "" >> $CLOUDFLARE_CONF;
-    echo "real_ip_header CF-Connecting-IP;" >> $CLOUDFLARE_CONF;
+        echo "# - IPv4" >> $CLOUDFLARE_CONF;
+        for i in `curl https://www.cloudflare.com/ips-v4`; do
+            echo "set_real_ip_from $i;" >> $CLOUDFLARE_CONF;
+        done
+        
+        echo "" >> $CLOUDFLARE_CONF;
+        echo "# - IPv6" >> $CLOUDFLARE_CONF;
+        for i in `curl https://www.cloudflare.com/ips-v6`; do
+            echo "set_real_ip_from $i;" >> $CLOUDFLARE_CONF;
+        done
+        
+        echo "" >> $CLOUDFLARE_CONF;
+        echo "real_ip_header ${CLOUDFLARE_REAL_IP_HEADER};" >> $CLOUDFLARE_CONF;
+    fi
 fi
 
 # Prepare config file

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -14,7 +14,7 @@ KEYFILE=$(jq --raw-output ".keyfile" $CONFIG_PATH)
 CERTFILE=$(jq --raw-output ".certfile" $CONFIG_PATH)
 HSTS=$(jq --raw-output ".hsts // empty" $CONFIG_PATH)
 CUSTOMIZE_ACTIVE=$(jq --raw-output ".customize.active" $CONFIG_PATH)
-CLOUDFLARE_ENABLED=$(jq --raw-output ".cloudflare.enabled" $CONFIG_PATH)
+CLOUDFLARE_ENABLE=$(jq --raw-output ".cloudflare.enable" $CONFIG_PATH)
 CLOUDFLARE_REAL_IP_HEADER=$(jq --raw-output ".cloudflare.real_ip_header" $CONFIG_PATH)
 
 # Generate dhparams

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -14,7 +14,7 @@ KEYFILE=$(jq --raw-output ".keyfile" $CONFIG_PATH)
 CERTFILE=$(jq --raw-output ".certfile" $CONFIG_PATH)
 HSTS=$(jq --raw-output ".hsts // empty" $CONFIG_PATH)
 CUSTOMIZE_ACTIVE=$(jq --raw-output ".customize.active" $CONFIG_PATH)
-CLOUDFLARE_ENABLE=$(jq --raw-output ".cloudflare.enable" $CONFIG_PATH)
+CLOUDFLARE=$(jq --raw-output ".cloudflare" $CONFIG_PATH)
 
 # Generate dhparams
 if [ ! -f "$DHPARAMS_PATH" ]; then
@@ -27,7 +27,7 @@ if [ ! -f "$SNAKEOIL_CERT" ]; then
     openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout $SNAKEOIL_KEY -out $SNAKEOIL_CERT -subj '/CN=localhost'
 fi
 
-if [ "$CLOUDFLARE_ENABLE" == "true" ]; then
+if [ "$CLOUDFLARE" == "true" ]; then
     sed -i "s|#include /data/cloudflare.conf;|include /data/cloudflare.conf;|" /etc/nginx.conf
     # Generate cloudflare.conf
     if [ ! -f "$CLOUDFLARE_CONF" ]; then

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -29,6 +29,7 @@ if [ ! -f "$SNAKEOIL_CERT" ]; then
 fi
 
 if [ "$CLOUDFLARE_ENABLED" == "true" ]; then
+    sed -i "s|#include /data/cloudflare.conf|include /data/cloudflare.conf;|" /etc/nginx.conf
     # Generate cloudflare.conf
     if [ ! -f "$CLOUDFLARE_CONF" ]; then
         echo "[INFO] Creating 'cloudflare.conf' for real visitor IP address..."

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -29,7 +29,7 @@ fi
 
 # Generate cloudflare.conf
 if [ ! -f "$CLOUDFLARE_CONF" ]; then
-   echo "[INFO] Creating 'cloudflare.conf' for set_real_ip_from..."
+   echo "[INFO] Creating 'cloudflare.conf' for real visitor IP address..."
    echo "# Cloudflare IP addresses" > $CLOUDFLARE_CONF;
    echo "" >> $CLOUDFLARE_CONF;
 

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -28,7 +28,7 @@ if [ ! -f "$SNAKEOIL_CERT" ]; then
     openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout $SNAKEOIL_KEY -out $SNAKEOIL_CERT -subj '/CN=localhost'
 fi
 
-if [ "$CLOUDFLARE_ENABLED" == "true" ]; then
+if [ "$CLOUDFLARE_ENABLE" == "true" ]; then
     sed -i "s|#include /data/cloudflare.conf;|include /data/cloudflare.conf;|" /etc/nginx.conf
     # Generate cloudflare.conf
     if [ ! -f "$CLOUDFLARE_CONF" ]; then

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -29,7 +29,7 @@ if [ ! -f "$SNAKEOIL_CERT" ]; then
 fi
 
 if [ "$CLOUDFLARE_ENABLED" == "true" ]; then
-    sed -i "s|#include /data/cloudflare.conf|include /data/cloudflare.conf;|" /etc/nginx.conf
+    sed -i "s|#include /data/cloudflare.conf;|include /data/cloudflare.conf;|" /etc/nginx.conf
     # Generate cloudflare.conf
     if [ ! -f "$CLOUDFLARE_CONF" ]; then
         echo "[INFO] Creating 'cloudflare.conf' for real visitor IP address..."


### PR DESCRIPTION
Added an optional Cloudflare mechanism for real visitor ip.
If enabled it will auto-generate /data/cloudflare.conf with a list of ipv4/ipv6 addresses directly from Cloudflare that will be used for set_real_ip_from.

The /data/cloudflare.conf will be included in the /etc/nginx.conf

This is so the ip_ban_enabled can be used and work correctly in /config/customize.yaml

Example:
http:
        base_url: !secret base_url
        use_x_forwarded_for: true
        trusted_proxies:
                - 127.0.0.1
                - 172.30.33.1
        ip_ban_enabled: true
        login_attempts_threshold: 5