### PR TITLE
Exempt "Help wanted" from Stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
+  - Help wanted
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Exempt "Help wanted" from stale bot. These issues mark a goal/feature/issue that we want to resolve and should not be closed by the stale bot.

The "Help wanted" label is helpful since GitHub understands this label as well (it triggers some features).