### PR TITLE
Move log message

### DIFF
--- a/check_config/CHANGELOG.md
+++ b/check_config/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1
+- moved the 'reassurance' log INFO message "Don't worry, this temporary installation is not overwriting your current one." to earlier in the process
+
 ## 3.0
 
 - Use Home Assistant base image as base for this Add-on

--- a/check_config/CHANGELOG.md
+++ b/check_config/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.1
-- moved the 'reassurance' log INFO message "Don't worry, this temporary installation is not overwriting your current one." to earlier in the process
+- Moved the 'reassurance' log message "Don't worry, this temporary installation is not overwriting your current one." to earlier in the process.
 
 ## 3.0
 

--- a/check_config/CHANGELOG.md
+++ b/check_config/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 3.1
+
 - Moved the 'reassurance' log message "Don't worry, this temporary installation is not overwriting your current one." to earlier in the process.
 
 ## 3.0

--- a/check_config/config.json
+++ b/check_config/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Check Home Assistant configuration",
-  "version": "3.0",
+  "version": "3.1",
   "slug": "check_config",
   "description": "Check current Home Assistant configuration against a new version",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/check_config",

--- a/check_config/data/run.sh
+++ b/check_config/data/run.sh
@@ -9,6 +9,7 @@ if [ "${VERSION}" != "latest" ]; then
     CMD="homeassistant==${VERSION}"
 fi
 
+bashio::log.info "Don't worry, this temporary installation is not overwriting your current one."
 bashio::log.info "Installing Home Assistant: ${VERSION}..."
 bashio::log.info "Please be patient, this might take a few minutes..."
 
@@ -20,7 +21,6 @@ if ! PIP_OUTPUT="$(pip3 install --find-links "${WHEELS_LINKS}" "${CMD}")"; then
 fi
 INSTALLED_VERSION="$(pip freeze | grep homeassistant)"
 bashio::log.info "Installed Home Assistant ${INSTALLED_VERSION##*=}"
-bashio::log.info "Don't worry, this temporary installation is not overwriting your current one."
 
 # Making an temporary copy of your configuration
 bashio::log.info "Making a copy of your configuration for checking..."


### PR DESCRIPTION
moved the 'reassurance' log INFO message "Don't worry, this temporary installation is not overwriting your current one." to earlier in the process.

In order to implement/resolve #705