### PR TITLE
Update samba add-on to use Bashio #735

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.2
+- Update from bash to bashio
+
 ## 8.1
 - Update Samba to version 4.8.8
 

--- a/samba/config.json
+++ b/samba/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Samba share",
-  "version": "8.1",
+  "version": "8.2",
   "slug": "samba",
   "description": "Expose Hass.io folders with SMB/CIFS",
   "url": "https://home-assistant.io/addons/samba/",

--- a/samba/run.sh
+++ b/samba/run.sh
@@ -12,7 +12,7 @@ NAME=
 
 # Check Login data
 if ! bashio::config.has_value 'username' || ! bashio::config.has_value 'password'; then
-    bashio::exit:nok "No valid login data inside options!"
+    bashio::exit.nok "No valid login data inside options!"
 fi
 
 # Read hostname from API or setting default "hassio"

--- a/samba/run.sh
+++ b/samba/run.sh
@@ -33,7 +33,7 @@ sed -i "s|%%INTERFACE%%|$INTERFACE|g" /etc/smb.conf
 sed -i "s|%%ALLOW_HOSTS%%|$ALLOW_HOSTS|g" /etc/smb.conf
 sed -i "s|%%USERNAME%%|$USERNAME|g" /etc/smb.conf
 
-echo "Allowed Hosts: " $ALLOW_HOSTS
+bashio::log.info "Allowed Hosts: " $ALLOW_HOSTS
 
 # Init users
 addgroup "${USERNAME}"

--- a/samba/run.sh
+++ b/samba/run.sh
@@ -24,15 +24,20 @@ else
     bashio::log.info "Read hostname: ${NAME}"
 fi
 
+# Workaround to create usable IPRanges from ALLOW_HOSTS variable
+IPRANGES=
+for item in $ALLOW_HOSTS; do
+         IPRANGES="$IPRANGES ${item}"
+     done
+
 # Setup config
-sed -i "s|%%WORKGROUP%%|$WORKGROUP|g" /etc/smb.conf
-sed -i "s|%%NAME%%|$NAME|g" /etc/smb.conf
-sed -i "s|%%INTERFACE%%|$INTERFACE|g" /etc/smb.conf
-sed -i "s|%%ALLOW_HOSTS%%|$ALLOW_HOSTS|g" /etc/smb.conf
-sed -i "s|%%USERNAME%%|$USERNAME|g" /etc/smb.conf
+sed -i "s|%%WORKGROUP%%|${WORKGROUP}|g" /etc/smb.conf
+sed -i "s|%%NAME%%|${NAME}|g" /etc/smb.conf
+sed -i "s|%%INTERFACE%%|${INTERFACE}|g" /etc/smb.conf
+sed -i "s|%%USERNAME%%|${USERNAME}|g" /etc/smb.conf
+sed -i "s#%%ALLOW_HOSTS%%#${IPRANGES}#g" /etc/smb.conf
 
-bashio::log.info "Allowed Hosts: " "$ALLOW_HOSTS"
-
+cat /etc/smb.conf
 # Init users
 addgroup "${USERNAME}"
 adduser -D -H -G "${USERNAME}" -s /bin/false "${USERNAME}"

--- a/samba/run.sh
+++ b/samba/run.sh
@@ -33,7 +33,7 @@ sed -i "s|%%INTERFACE%%|$INTERFACE|g" /etc/smb.conf
 sed -i "s|%%ALLOW_HOSTS%%|$ALLOW_HOSTS|g" /etc/smb.conf
 sed -i "s|%%USERNAME%%|$USERNAME|g" /etc/smb.conf
 
-bashio::log.info "Allowed Hosts: " $ALLOW_HOSTS
+bashio::log.info "Allowed Hosts: " "$ALLOW_HOSTS"
 
 # Init users
 addgroup "${USERNAME}"

--- a/samba/run.sh
+++ b/samba/run.sh
@@ -1,29 +1,29 @@
-#!/bin/bash
+#!/usr/bin/env bashio
 set -e
 
 CONFIG_PATH=/data/options.json
 
-WORKGROUP=$(jq --raw-output '.workgroup' $CONFIG_PATH)
-INTERFACE=$(jq --raw-output '.interface // empty' $CONFIG_PATH)
-ALLOW_HOSTS=$(jq --raw-output '.allow_hosts | join(" ")' $CONFIG_PATH)
-USERNAME=$(jq --raw-output '.username // empty' $CONFIG_PATH)
-PASSWORD=$(jq --raw-output '.password // empty' $CONFIG_PATH)
+WORKGROUP=$(bashio::config 'workgroup')
+INTERFACE=$(bashio::config 'interface')
+ALLOW_HOSTS=$(bashio::config 'allow_hosts')
+USERNAME=$(bashio::config 'username')
+PASSWORD=$(bashio::config 'password')
 
 WAIT_PIDS=()
 NAME=
 
 # Check Login data
 if [ -z "${USERNAME}" ] || [ -z "${PASSWORD}" ]; then
-    echo "[ERROR] No valid login data inside options!"
+    bashio::log.error "No valid login data inside options!"
     exit 1
 fi
 
 # Read hostname from API
 if ! NAME="$(curl -s -f -H "X-Hassio-Key: ${HASSIO_TOKEN}" http://hassio/info | jq --raw-output '.data.hostname')"; then
-    echo "[WARN] Can't read hostname, use default!"
+    bashio::log.warn "Can't read hostname, use default!"
     NAME="hassio"
 else
-    echo "[INFO] Read hostname: ${NAME}"
+    bashio::log.info "Read hostname: ${NAME}"
 fi
 
 # Setup config
@@ -32,6 +32,8 @@ sed -i "s|%%NAME%%|$NAME|g" /etc/smb.conf
 sed -i "s|%%INTERFACE%%|$INTERFACE|g" /etc/smb.conf
 sed -i "s|%%ALLOW_HOSTS%%|$ALLOW_HOSTS|g" /etc/smb.conf
 sed -i "s|%%USERNAME%%|$USERNAME|g" /etc/smb.conf
+
+echo "Allowed Hosts: " $ALLOW_HOSTS
 
 # Init users
 addgroup "${USERNAME}"
@@ -48,10 +50,10 @@ WAIT_PIDS+=($!)
 
 # Register stop
 function stop_samba() {
-    echo "Kill Processes..."
+    bashio::log.info "Kill Processes..."
     kill -15 "${WAIT_PIDS[@]}"
     wait "${WAIT_PIDS[@]}"
-    echo "Done."
+    bashio::log.info "Done."
 }
 trap "stop_samba" SIGTERM SIGHUP
 

--- a/samba/run.sh
+++ b/samba/run.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bashio
 set -e
 
-CONFIG_PATH=/data/options.json
-
 WORKGROUP=$(bashio::config 'workgroup')
 INTERFACE=$(bashio::config 'interface')
 ALLOW_HOSTS=$(bashio::config 'allow_hosts')

--- a/samba/run.sh
+++ b/samba/run.sh
@@ -12,8 +12,7 @@ NAME=
 
 # Check Login data
 if ! bashio::config.has_value 'username' || ! bashio::config.has_value 'password'; then
-    bashio::log.error "No valid login data inside options!"
-    exit 1
+    bashio::exit:nok "No valid login data inside options!"
 fi
 
 # Read hostname from API or setting default "hassio"


### PR DESCRIPTION
Still have an error, which im looking for some feedback in order to fix it:

`sed: unmatched '|'`

caused by:
`sed -i "s|%%ALLOW_HOSTS%%|$ALLOW_HOSTS|g" /etc/smb.conf`

closes #735