### PR TITLE
Delay shutting down the PC

### DIFF
--- a/rpc_shutdown/CHANGELOG.md
+++ b/rpc_shutdown/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
 
+## 2.0
+
+- New option to delay shutting down the Windows PC
+- New option to send a message to the PC that is about to be shut down. If somebody is using the PC, you can warn them to save their work.
+
 ## 1.0
 - Update samba 4.8.8

--- a/rpc_shutdown/config.json
+++ b/rpc_shutdown/config.json
@@ -1,6 +1,6 @@
 {
   "name": "RPC Shutdown",
-  "version": "1.0",
+  "version": "2.0",
   "slug": "rpc_shutdown",
   "description": "Simple way for remote windows shutdowns",
   "url": "https://home-assistant.io/addons/rpc_shutdown/",
@@ -14,7 +14,9 @@
       {
         "alias": "test-pc",
         "address": "192.168.0.1",
-        "credentials": "user%password"
+        "credentials": "user%password",
+        "delay": "0",
+        "message": "Home Assistant is shutting down this PC. This cannot be canceled. Please save your work!"
       }
     ]
   },
@@ -23,7 +25,9 @@
       {
         "alias": "match(^[\\w-]*$)",
         "address": "str",
-        "credentials": "match(^[^%]*(?:%[^%]*)?$)"
+        "credentials": "match(^[^%]*(?:%[^%]*)?$)",
+        "delay": "int(0,600)?",
+        "message": "str?"
       }
     ]
   },

--- a/rpc_shutdown/config.json
+++ b/rpc_shutdown/config.json
@@ -15,7 +15,7 @@
         "alias": "test-pc",
         "address": "192.168.0.1",
         "credentials": "user%password",
-        "delay": "0",
+        "delay": 0,
         "message": "Home Assistant is shutting down this PC. This cannot be canceled. Please save your work!"
       }
     ]

--- a/rpc_shutdown/run.sh
+++ b/rpc_shutdown/run.sh
@@ -16,14 +16,21 @@ while read -r input; do
         ALIAS=$(jq --raw-output ".computers[$i].alias" $CONFIG_PATH)
         ADDRESS=$(jq --raw-output ".computers[$i].address" $CONFIG_PATH)
         CREDENTIALS=$(jq --raw-output ".computers[$i].credentials" $CONFIG_PATH)
+        DELAY=$(jq --raw-output ".computers[$i].delay" $CONFIG_PATH)
+        MESSAGE=$(jq --raw-output ".computers[$i].message" $CONFIG_PATH)
       
         # Not the correct alias
         if [ "$ALIAS" != "$input" ]; then
             continue
         fi
       
+	  # Check if delay is not empty
+        if [ "$DELAY" = "" ]; then
+            DELAY="0"
+        fi
+
         echo "[Info] Shutdown $input -> $ADDRESS"
-        if ! msg="$(net rpc shutdown -I "$ADDRESS" -U "$CREDENTIALS")"; then
+        if ! msg="$(net rpc shutdown -I "$ADDRESS" -U "$CREDENTIALS" -t "$DELAY" -C "$MESSAGE")"; then
             echo "[Error] Shutdown fails -> $msg"
         fi
     done

--- a/rpc_shutdown/run.sh
+++ b/rpc_shutdown/run.sh
@@ -24,11 +24,6 @@ while read -r input; do
             continue
         fi
       
-	  # Check if delay is not empty
-        if [ "$DELAY" = "" ]; then
-            DELAY="0"
-        fi
-
         echo "[Info] Shutdown $input -> $ADDRESS"
         if ! msg="$(net rpc shutdown -I "$ADDRESS" -U "$CREDENTIALS" -t "$DELAY" -C "$MESSAGE")"; then
             echo "[Error] Shutdown fails -> $msg"


### PR DESCRIPTION
Added 2 new options:
- New option to delay shutting down the Windows PC
- New option to send a message to the PC that is about to be shut down. If somebody is using the PC, you can warn them to save their work.

I tested the command locally, and the -t and -C arguments work as expected.

I've never editted a .bash file before, so this needs to be checked!

new variables are marked with a ? This should mean that they are optional (I don't want to break anyone's configuration.
