### PR TITLE
samba: Fixes startup error and some minor cleanups

### DIFF
--- a/samba/CHANGELOG.md
+++ b/samba/CHANGELOG.md
@@ -1,30 +1,44 @@
 # Changelog
 
+## 8.3
+
+- Fixes a bug in warning log message, causing start failure
+- Minor code cleanups
+
 ## 8.2
+
 - Update from bash to bashio
 
 ## 8.1
+
 - Update Samba to version 4.8.8
 
 ## 8.0
+
 - Fix access to /backup
 
 ## 7.0
+
 - Remove guest access
 - Cleanup structure
 - Use hostname for samba device name
 
 ## 6.0
+
 - Enable ntlm auth for Windows10
 
 ## 5.0
+
 - Update Samba to version 4.8.4
 
 ## 4.1
+
 - Bugfix sed command
 
 ## 4.0
+
 - New option `allow_hosts` to limit access
 
 ## 3.0
+
 - Update base image

--- a/samba/Dockerfile
+++ b/samba/Dockerfile
@@ -6,7 +6,9 @@ ENV LANG C.UTF-8
 
 # Setup base
 RUN apk add --no-cache \
-        curl samba-server samba-common-tools
+        curl \
+        samba-common-tools \
+        samba-server
 
 # Copy data
 COPY run.sh /

--- a/samba/README.md
+++ b/samba/README.md
@@ -19,12 +19,10 @@ The installation of this add-on is straightforward and easy to do.
 
 ## How to use
 
-In the configuration section, define a username and password and save the configuration 
-
-
-1. Start the add-on.
-2. Have some patience and wait a couple of minutes.
-3. Check the add-on log output to see the result.
+1. In the configuration section, set a username and password.
+2. Save the configuration.
+3. Start the add-on.
+4. Check the add-on log output to see the result.
 
 ## Configuration
 

--- a/samba/config.json
+++ b/samba/config.json
@@ -1,23 +1,35 @@
 {
   "name": "Samba share",
-  "version": "8.2",
+  "version": "8.3",
   "slug": "samba",
   "description": "Expose Hass.io folders with SMB/CIFS",
   "url": "https://home-assistant.io/addons/samba/",
-  "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
+  "arch": [
+    "armhf",
+    "armv7",
+    "aarch64",
+    "amd64",
+    "i386"
+  ],
   "startup": "services",
   "boot": "auto",
   "host_network": true,
-  "map": ["config:rw", "ssl:rw", "addons:rw", "share:rw", "backup:rw"],
+  "map": [
+    "config:rw",
+    "ssl:rw",
+    "addons:rw",
+    "share:rw",
+    "backup:rw"
+  ],
   "options": {
     "workgroup": "WORKGROUP",
     "username": "hassio",
     "password": null,
     "interface": "",
     "allow_hosts": [
-        "10.0.0.0/8",
-        "172.16.0.0/12",
-        "192.168.0.0/16"
+      "10.0.0.0/8",
+      "172.16.0.0/12",
+      "192.168.0.0/16"
     ]
   },
   "schema": {
@@ -25,7 +37,9 @@
     "username": "str",
     "password": "str",
     "interface": "str",
-    "allow_hosts": ["str"]
+    "allow_hosts": [
+      "str"
+    ]
   },
   "image": "homeassistant/{arch}-addon-samba"
 }

--- a/samba/run.sh
+++ b/samba/run.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bashio
-set -e
 
 WORKGROUP=$(bashio::config 'workgroup')
 INTERFACE=$(bashio::config 'interface')
@@ -8,7 +7,6 @@ USERNAME=$(bashio::config 'username')
 PASSWORD=$(bashio::config 'password')
 
 WAIT_PIDS=()
-NAME=
 
 # Check Login data
 if ! bashio::config.has_value 'username' || ! bashio::config.has_value 'password'; then
@@ -18,7 +16,7 @@ fi
 # Read hostname from API or setting default "hassio"
 NAME=$(bashio::info.hostname)
 if bashio::var.is_empty "${NAME}"; then
-    bashio::log.warn "Can't read hostname, using default."
+    bashio::log.warning "Can't read hostname, using default."
     NAME="hassio"
 fi
 bashio::log.info "Hostname: ${NAME}"


### PR DESCRIPTION
This addresses a startup issue with Samba that not occurred during my testing.

The `log.warn` function call was incorrect, it had to be `log.warning`, which now causes the add-on failing to start in some cases.

Furthermore, added some small cleanups and adjusted the "How to use" part of the documentation a bit, to make it more clear one would have to set a username & password before starting the add-on.

Fixes #774

