### PR TITLE
Bugfix when Delay parameter is missing in configuration

### DIFF
--- a/rpc_shutdown/CHANGELOG.md
+++ b/rpc_shutdown/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2
+
+- Set delay to zero when it is empty (to not break existing configurations) (bugfix)
+
 ## 2.1
 
 - Set delay to zero when it is empty (to not break existing configurations)

--- a/rpc_shutdown/config.json
+++ b/rpc_shutdown/config.json
@@ -1,6 +1,6 @@
 {
   "name": "RPC Shutdown",
-  "version": "2.1",
+  "version": "2.2",
   "slug": "rpc_shutdown",
   "description": "Simple way for remote windows shutdowns",
   "url": "https://home-assistant.io/addons/rpc_shutdown/",

--- a/rpc_shutdown/run.sh
+++ b/rpc_shutdown/run.sh
@@ -21,7 +21,7 @@ while read -r input; do
         fi
 
         # Check if delay is not empty
-        if bashio::var.is_empty "${DELAY}"; then
+        if bashio::var.equals "$DELAY" "null"; then
             DELAY="0"
         fi
 


### PR DESCRIPTION
When a user updates this addon to latest version, the new Delay parameter is missing (because it is an optional parameter).
Now the addon crashes with message: Invalid option null: invalid numeric value

What happens is, in run.sh, line 15. bashio::config tries to read configuration key Delay. This does not exist, so the function returns the string "null" (not actual null).

Now the if statement on line 24 does not work (the string is not empty).
I fixed the if on line 24

