### PR TITLE
Remove unsupported architectures from Homematic README

### DIFF
--- a/homematic/README.md
+++ b/homematic/README.md
@@ -165,9 +165,9 @@ You have several options to get them answered:
 
 In case you've found an bug, please [open an issue on our GitHub][issue].
 
-[aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
-[amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
+[aarch64-shield]: https://img.shields.io/badge/aarch64-no-red.svg
+[amd64-shield]: https://img.shields.io/badge/amd64-no-red.svg
+[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [discord]: https://discord.gg/c5DvZ4e
 [forum]: https://community.home-assistant.io


### PR DESCRIPTION
You might want to double check that I am right about these architectures not being supported.