### PR TITLE
New deconz.dresden-elektronik.de subdomain

### DIFF
--- a/deconz/Dockerfile
+++ b/deconz/Dockerfile
@@ -42,12 +42,12 @@ RUN apt-get update \
 ARG DECONZ_VERSION
 RUN if [ "${BUILD_ARCH}" = "armhf" ]; \
         then \
-            curl -q -L -o /deconz.deb https://www.dresden-elektronik.de/rpi/deconz/beta/deconz-${DECONZ_VERSION}-qt5.deb; \
+            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/raspbian/beta/deconz-${DECONZ_VERSION}-qt5.deb; \
         elif [ "${BUILD_ARCH}" = "aarch64" ]; \
         then \
-            curl -q -L -o /deconz.deb https://www.dresden-elektronik.de/rpi/deconz/alpha/deconz_${DECONZ_VERSION}-debian-stretch-beta_arm64.deb; \
+            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/raspbian/alpha/deconz_${DECONZ_VERSION}-debian-stretch-beta_arm64.deb; \
         else \
-            curl -q -L -o /deconz.deb https://www.dresden-elektronik.de/deconz/ubuntu/beta/deconz-${DECONZ_VERSION}-qt5.deb; \
+            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/ubuntu/beta/deconz-${DECONZ_VERSION}-qt5.deb; \
         fi \
     && dpkg -i /deconz.deb \
     && rm -f /deconz.deb \


### PR DESCRIPTION
Due a new website on dresden-elektronik.de, the old paths might not work for some time.
The redirection of links should be active very soon.

This PR uses the deconz. subdomain to fix the 404, note https version will follow soon.