### PR TITLE
Additional audioServer topics created by Snips platform

### DIFF
--- a/snips/CHANGELOG.md
+++ b/snips/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.1
+
+- set hermes/audioServer/+/playBytesStreaming/# to allow subscribing from other systems
+- set hermes/audioServer/+/streamFinished to allow subscribing from other systems
+
 ## 6.0
 
 - Updated to snips 0.64.0

--- a/snips/config.json
+++ b/snips/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Snips.AI",
-  "version": "6.0",
+  "version": "6.1",
   "slug": "snips",
   "description": "Local voice control platform",
   "url": "https://home-assistant.io/addons/snips/",

--- a/snips/run.sh
+++ b/snips/run.sh
@@ -63,6 +63,8 @@ if MQTT_CONFIG="$(curl -s -f -H "X-Hassio-Key: ${HASSIO_TOKEN}" http://hassio/se
         echo "topic hermes/nlu/intentNotParsed out"
         echo "topic hermes/audioServer/+/playBytes/# out"
         echo "topic hermes/audioServer/+/playFinished out"
+        echo "topic hermes/audioServer/+/playBytesStreaming/# out"
+        echo "topic hermes/audioServer/+/streamFinished out"
         echo "topic # IN hermes/"
     ) >> /etc/mosquitto.conf
 else


### PR DESCRIPTION
Snips has added extra topics to provide streaming of bytes.
See the reference here: https://docs.snips.ai/reference/hermes#streaming-a-sound

Those topics should also be out in the bridging, so that other devices are able to respond properly