### PR TITLE
almond: tag the Home Assistant skill as hassio-configured

### DIFF
--- a/almond/CHANGELOG.md
+++ b/almond/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6
+
+- Fix issue with restart / Hass.io token handling
+
 ## 0.5
 
 - Update Almond to 1.7.1

--- a/almond/config.json
+++ b/almond/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Almond",
-  "version": "0.5",
+  "version": "0.6",
   "slug": "almond",
   "description": "The home server version of Almond",
   "url": "https://home-assistant.io/addons/almond/",

--- a/almond/data/run.sh
+++ b/almond/data/run.sh
@@ -15,6 +15,7 @@ almond_config=$(\
         accessToken "${HASSIO_TOKEN}" \
         refreshToken "" \
         accessTokenExpires "^${TOKEN_VALID}" \
+        isHassio "^true" \
 )
 
 # HA Discovery


### PR DESCRIPTION
Which triggers the correct behavior on the Almond-side wrt temporary
access tokens