### PR TITLE
Fix build, using new GPG keys from Snips

### DIFF
--- a/snips/Dockerfile
+++ b/snips/Dockerfile
@@ -11,20 +11,21 @@ ARG BUILD_ARCH
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        dirmngr \
-        apt-utils \
         apt-transport-https \
-        unzip \
-        supervisor \
+        apt-utils \
+        dirmngr \
+        gnupg-curl \
         mpg123 \
+        supervisor \
+        unzip \
     && rm -rf /var/lib/apt/lists/* \
     && if [ "$BUILD_ARCH" = "amd64" ]; \
         then \
             bash -c 'echo "deb https://debian.snips.ai/stretch stable main" > /etc/apt/sources.list.d/snips.list' \
-            && apt-key adv --keyserver pgp.surfnet.nl --recv-keys F727C778CCB0A455; \
+            && apt-key adv --fetch-keys https://debian.snips.ai/5FFCD0DEB5BA45CD.pub; \
         else \
             bash -c 'echo "deb https://raspbian.snips.ai/stretch stable main" > /etc/apt/sources.list.d/snips.list' \
-            && apt-key adv --keyserver pgp.surfnet.nl --recv-keys D4F50CDCA10A2849; \
+            && apt-key adv --fetch-keys https://raspbian.snips.ai/531DD1A7B702B14D.pub; \
         fi
 
 ARG SNIPS_VERSION


### PR DESCRIPTION
Seems like Snips uses a new GPG signing key for their APT repositories, which are no longer to be found on the SKS keyservers.

This PR adds `gnupg-curl` and fetches the public GPG keys directly from their servers.

fixes #845