### PR TITLE
git_pull: Added option to specify config directory in git repo

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.7
+
+- Added git_config_dir option to allow a location on repo for config directory to be specified
+
 ## 7.6
 
 - Update Hass.io CLI to 3.1.0

--- a/git_pull/README.md
+++ b/git_pull/README.md
@@ -46,6 +46,7 @@ Add-on configuration:
   "git_command": "pull",
   "git_remote": "origin",
   "git_prune": "false",
+  "git_config_directory": "/",
   "repository": "https://example.com/my_configs.git",
   "auto_restart": false,
   "restart_ignore": [
@@ -79,6 +80,10 @@ Name of the tracked repository. Leave this as `origin` if you are unsure.
 ### Option: `git_prune` (required)
 
 `true`/`false`: If set to true, the add-on will clean-up branches that are deleted on the remote repository, but still have cached entries on the local machine. Leave this as `false` if you are unsure.
+
+### Option `git_config_dir` (required)
+
+Name of the directory in your git repository to copy to your "/config" directory. Defaults to `/` (the root of your repository)
 
 ### Option: `git_branch` (required)
 

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -19,6 +19,7 @@
     "git_command": "pull",
     "git_remote": "origin",
     "git_prune": false,
+    "git_config_dir": "/",
     "repository": null,
     "auto_restart": false,
     "restart_ignore": [
@@ -39,6 +40,7 @@
     "git_command": "match(pull|reset)",
     "git_remote": "str",
     "git_prune": "bool",
+    "git_config_dir": "str",
     "repository": "match((?:.+):(\/\/)?(.*?)(\\.git)(\/?|\\#[-\\d\\w._]+?))",
     "auto_restart": "bool",
     "restart_ignore": ["str"],

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "7.6",
+  "version": "7.7",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://home-assistant.io/addons/git_pull/",

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -56,7 +56,7 @@ function git-clone {
     git clone "$REPOSITORY" /config-store || { echo "[Error] Git clone failed"; exit 1; }
 
     # Step into config directory
-    pushd $(realpath -s "config-store/${GIT_CONFIG_DIR}") || { echo "[Error] Unable to move into git config directory"; exit 1; }
+    pushd "$(realpath -s "config-store/${GIT_CONFIG_DIR}")" || { echo "[Error] Unable to move into git config directory"; exit 1; }
     
     # Get list of ignored files for rsync to filter over
     echo "[Info] Generating list of ignored files from git"

--- a/git_pull/run.sh
+++ b/git_pull/run.sh
@@ -56,17 +56,17 @@ function git-clone {
     git clone "$REPOSITORY" /config-store || { echo "[Error] Git clone failed"; exit 1; }
 
     # Step into config directory
-    pushd $(realpath -s config-store/${GIT_CONFIG_DIR}) || { echo "[Error] Unable to move into git config directory"; exit 1; }
+    pushd $(realpath -s "config-store/${GIT_CONFIG_DIR}") || { echo "[Error] Unable to move into git config directory"; exit 1; }
     
     # Get list of ignored files for rsync to filter over
     echo "[Info] Generating list of ignored files from git"
     echo ".git" > /tmp/rsync-ignore.txt
-    git status --ignored -s | egrep '^\!\!' | sed 's/!! //' >> /tmp/rsync-ignore.txt
+    git status --ignored -s | grep -E '^\!\!' | sed 's/!! //' >> /tmp/rsync-ignore.txt
     
     # Copy files from git config dir to /config, excluding files not covered by git
     echo "[Info] Moving config from git dir to local"
     rsync -a --delete --exclude-from=/tmp/rsync-ignore.txt ./* /config || { echo "[Error] Failed to sync remote config to local config directory"; exit 1; }
-    popd
+    popd || { echo "[Error] Failed to return to previous directory"; exit 1; }
 
     # try to copy non yml files back
     cp "${BACKUP_LOCATION}" "!(*.yaml)" /config 2>/dev/null


### PR DESCRIPTION
Added `git_config_dir` to the options to allo user to specify the config directory in their git repository.

In order to preserve previous default behaviour, this defaults to `/` (the root of the git repo)

As an added bonus, this also ensures that .gitignore'd files are not overwritten in the copy process.