### PR TITLE
Add DHCP options for dnsmasq

### DIFF
--- a/dnsmasq/README.md
+++ b/dnsmasq/README.md
@@ -142,21 +142,21 @@ The network gateway to return for DHCP requests.
 This option enables Dnsmasq to respond to DHCP requests on the specified
 networks.
 
-#### Option: `networks` -> `broadcast`
+#### Option: `networks.broadcast`
 
 The broadcast address of the network where DHCP will be enabled.
 
-#### Option: `networks` -> `netmask`
+#### Option: `networks.netmask`
 
 The subnet mask of the network where DHCP will be enabled.
 
-#### Option: `networks` -> `range_start`
+#### Option: `networks.range_start`
 
 Defines the start IP address for the DHCP server to lease IPs for.
 Use this together with the range_end option to define the range of IP
 addresses the DHCP server operates in.
 
-#### Option: `networks` -> `range_end`
+#### Option: `networks.range_end`
 
 Defines the end IP address on the network where the DHCP server will lease IPs.
 

--- a/dnsmasq/README.md
+++ b/dnsmasq/README.md
@@ -6,9 +6,10 @@ A simple DNS server.
 
 ## About
 
-Setup and manage a Dnsmasq DNS server. This allows you to manipulate DNS
-requests. For example, you can have your Home Assistant domain resolve with
-an internal address inside your network.
+Setup and manage a Dnsmasq DNS and DHCP server. The DNS service allows for
+serving or manipulating DNS requests. The DHCP service will perform IP address
+assignment and integrates well with the DNS service. For example, you can have
+your Home Assistant domain resolve with an internal address inside your network.
 
 ## Installation
 
@@ -40,6 +41,33 @@ Example add-on configuration:
   ],
   "hosts": [
     {"host": "home.mydomain.io", "ip": "192.168.1.10"}
+  ],
+  "networks": []
+}
+```
+
+Another example add-on configuration:
+
+```json
+{
+  "defaults": ["8.8.8.8", "8.8.4.4"],
+  "forwards": [],
+  "domain": "mynetwork.local",
+  "lease_time": "6h",
+  "networks": [
+    {
+      "netmask": "255.255.255.0",
+      "range_start": "192.168.1.100",
+      "range_end": "192.168.1.200",
+      "broadcast": "192.168.1.255"
+    }
+  ],
+  "hosts": [
+    {
+      "host": "webcam_xy",
+      "mac": "aa:bb:ee:cc",
+      "ip": "192.168.1.40"
+    }
   ]
 }
 ```
@@ -83,6 +111,54 @@ The hostname or domainname to resolve locally.
 #### Option: `hosts.ip`
 
 The IP address Dnsmasq should respond with in its DNS answer.
+
+#### Option: `hosts` -> `mac`
+
+The MAC address of the host. Setting this will allow Dnsmasq to return a
+static DHCP reserved address.
+
+#### Option: `interface`
+
+The network interface on which to listen for DNS and DHCP requests.
+
+#### Option: `address`
+
+The network address on which to listen for DNS and DHCP requests.
+
+#### Option: `lease_time`
+
+The time for DHCP leases to be valid.
+
+#### Option: `domain`
+
+The DNS domain to return for DHCP requests.
+
+#### Option: `gateway`
+
+The network gateway to return for DHCP requests.
+
+### Option: `networks` (optional)
+
+This option enables Dnsmasq to respond to DHCP requests on the specified
+networks.
+
+#### Option: `networks` -> `broadcast`
+
+The broadcast address of the network where DHCP will be enabled.
+
+#### Option: `networks` -> `netmask`
+
+The subnet mask of the network where DHCP will be enabled.
+
+#### Option: `networks` -> `range_start`
+
+Defines the start IP address for the DHCP server to lease IPs for.
+Use this together with the range_end option to define the range of IP
+addresses the DHCP server operates in.
+
+#### Option: `networks` -> `range_end`
+
+Defines the end IP address on the network where the DHCP server will lease IPs.
 
 ## Support
 

--- a/dnsmasq/config.json
+++ b/dnsmasq/config.json
@@ -7,14 +7,12 @@
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "system",
   "boot": "auto",
-  "ports": {
-    "53/tcp": 53,
-    "53/udp": 53
-  },
+  "host_network": true,
   "options": {
     "defaults": ["8.8.8.8", "8.8.4.4"],
     "forwards": [],
-    "hosts": []
+    "hosts": [],
+    "networks": []
   },
   "schema": {
     "defaults": ["str"],
@@ -24,12 +22,26 @@
         "server": "str"
       }
     ],
-    "hosts": [
-      {
-        "host": "str",
-        "ip": "str"
-      }
-    ]
+    "forwards": [{
+      "domain": "str",
+      "server": "str"
+    }],
+    "hosts": [{
+      "host": "str",
+      "mac": "str?",
+      "ip": "str"
+    }],
+    "interface": "str?",
+    "address": "str?",
+    "lease_time": "str?",
+    "domain": "str?",
+    "gateway": "str?",
+    "networks": [{
+      "broadcast": "str",
+      "netmask": "str",
+      "range_start": "str",
+      "range_end": "str"
+    }]
   },
   "image": "homeassistant/{arch}-addon-dnsmasq"
 }

--- a/dnsmasq/config.json
+++ b/dnsmasq/config.json
@@ -22,15 +22,13 @@
         "server": "str"
       }
     ],
-    "forwards": [{
-      "domain": "str",
-      "server": "str"
-    }],
-    "hosts": [{
-      "host": "str",
-      "mac": "str?",
-      "ip": "str"
-    }],
+    "hosts": [
+      {
+        "host": "str",
+        "mac": "str?",
+        "ip": "str"
+      }
+    ],
     "interface": "str?",
     "address": "str?",
     "lease_time": "str?",

--- a/dnsmasq/data/run.sh
+++ b/dnsmasq/data/run.sh
@@ -5,6 +5,18 @@ CONFIG="/etc/dnsmasq.conf"
 
 bashio::log.info "Configuring dnsmasq..."
 
+if ! bashio::config.is_empty 'interface';
+then
+    INTERFACE=$(bashio::config 'interface')
+    echo "interface=${INTERFACE}" >> "${CONFIG}"
+fi
+
+if ! bashio::config.is_empty 'listen_address';
+then
+    ADDRESS=$(bashio::config 'listen_address')
+    echo "listen-address=${ADDRESS}" >> "${CONFIG}"
+fi
+
 # Add default forward servers
 for server in $(bashio::config 'defaults'); do
     echo "server=${server}" >> "${CONFIG}"
@@ -24,6 +36,51 @@ for host in $(bashio::config 'hosts|keys'); do
     IP=$(bashio::config "hosts[${host}].ip")
 
     echo "address=/${HOST}/${IP}" >> "${CONFIG}"
+done
+
+# Create DHCP config
+if ! bashio::config.is_empty 'dhcp.lease_time';
+then
+    LEASE_TIME=$(bashio::config 'dhcp.lease_time')
+else
+    LEASE_TIME='12h'
+fi
+
+if ! bashio::config.is_empty 'dhcp.dns';
+then
+    DNS=$(bashio::config 'dhcp.dns|join(",")')
+    echo "dhcp-option=3,${DNS}" >> "${CONFIG}"
+fi
+
+if ! bashio::config.is_empty 'dhcp.domain';
+then
+    DOMAIN=$(bashio::config 'dhcp.domain')
+    echo "domain=${DOMAIN}" >> "${CONFIG}"
+fi
+
+if ! bashio::config.is_empty 'dhcp.gateway';
+then
+    GATEWAY=$(bashio::config 'dhcp.gateway')
+    echo "dhcp-option=3,${GATEWAY}" >> "${CONFIG}"
+fi
+
+echo "dhcp-authoritative" >> "${CONFIG}"
+
+# Create networks
+for network in $(bashio::config 'dhcp.networks|keys'); do
+    BROADCAST=$(bashio::config "dhcp.networks[${network}].broadcast")
+    NETMASK=$(bashio::config "dhcp.networks[${network}].netmask")
+    RANGE_END=$(bashio::config "dhcp.networks[${network}].range_end")
+    RANGE_START=$(bashio::config "dhcp.networks[${network}].range_start")
+    echo "dhcp-range=${RANGE_START},${RANGE_END},${NETMASK},${BROADCAST},${LEASE_TIME}" >> "${CONFIG}"
+done
+
+# Create hosts
+for host in $(bashio::config 'dhcp.hosts|keys'); do
+    IP=$(bashio::config "dhcp.hosts[${host}].ip")
+    MAC=$(bashio::config "dhcp.hosts[${host}].mac")
+    NAME=$(bashio::config "dhcp.hosts[${host}].name")
+    echo "dhcp-host=${MAC},${IP},${NAME},${LEASE_TIME}" >> "${CONFIG}"
 done
 
 # Run dnsmasq


### PR DESCRIPTION
This adds config options for DHCP into the dnsmasq tool. This allows some advantages such as specifying the listening interface and address, and integration of DHCP and DNS.

Fixes #628 