### PR TITLE
Implement auto-detecting IPv4/IPv6 addresses for DuckDNS

### DIFF
--- a/duckdns/README.md
+++ b/duckdns/README.md
@@ -75,6 +75,14 @@ A list of DuckDNS subdomains registered under your account. An acceptable naming
 
 The number of seconds to wait before updating DuckDNS subdomains and renewing Let's Encrypt certificates.
 
+### Option: `ipv4`
+
+The IPv4 address to configure in DuckDNS. Leave empty to let DuckDNS do the auto-detection or enter `detect` to let the addon use ipv4.wtfismyip.com to detect an IPv4 address.
+
+### Option: `ipv6`
+
+The IPv6 address to configure in DuckDNS. Leave empty to ignore IPv6 or enter `detect` to let the addon use ipv6.wtfismyip.com to detect an IPv6 address.
+
 ## Known issues and limitations
 
 - To log in, DuckDNS requires a free account from any of the following services: Google, Github, Twitter, Persona or Reddit.

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -48,6 +48,20 @@ if bashio::config.true 'lets_encrypt.accept_terms'; then
     fi
 fi
 
+# Get IPv4 address
+if bashio::config.equals 'ipv4' 'detect'; then
+    IPV4="$(curl -sk "https://ipv4.wtfismyip.com/text")"
+
+    bashio::log.info "Auto-detected IPv4 address: ${IPV4}"
+fi
+
+# Get IPv6 address 
+if bashio::config.equals 'ipv6' 'detect'; then
+    IPV6="$(curl -sk "https://ipv6.wtfismyip.com/text")"
+
+    bashio::log.info "Auto-detected IPv6 address: ${IPV6}"
+fi
+
 # Run duckdns
 while true; do
     if answer="$(curl -sk "https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ip=${IPV4}&ipv6=${IPV6}&verbose=true")"; then


### PR DESCRIPTION
By implementing this on the client side, it allows us to use IPv6 instead of relying on DuckDNS to do the detection for us - which is IPv6 or IPv4 only. This because they're unable to detect both addresses in a single request.

I wasn't unfortunately able to test this on my local HassIO. Is there any documentation available to test this? Because when restarting the container, it is of course restored to the default.