### PR TITLE
configurator: Fix and enforce secure base path

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.1
+
+- Fixes an issue with the enforce base path option
+- Enforce secure base path by default
+
 ## 4.0
 
 - Removed direct access from the add-on, making the add-on Ingress only

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -14,7 +14,7 @@
   "map": ["backup:rw", "config:rw", "share:rw", "ssl:rw"],
   "options": {
     "dirsfirst": false,
-    "enforce_basepath": false,
+    "enforce_basepath": true,
     "ignore_pattern": ["__pycache__", ".cloud", ".storage", "deps"],
     "ssh_keys": []
   },

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Configurator",
-  "version": "4.0",
+  "version": "4.1",
   "slug": "configurator",
   "description": "Browser-based configuration file editor for Home Assistant",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/configurator",

--- a/configurator/data/run.sh
+++ b/configurator/data/run.sh
@@ -32,7 +32,7 @@ fi
 # Setup and run configurator
 export HC_HASS_API_PASSWORD="${HASSIO_TOKEN}"
 export HC_DIRFIRST="${DIRSFIRST}"
-export HC_ENFORECE_BASEPATH="${ENFORCE_BASEPATH}"
+export HC_ENFORCE_BASEPATH="${ENFORCE_BASEPATH}"
 export HC_IGNORE_PATTERN="${IGNORE_PATTERN}"
 
 exec hass-configurator /etc/configurator.conf


### PR DESCRIPTION
This PR fixes #904

I've also set the default add-on configuration for the `secure_basepath` to `true`. Simply because this is a safer and saner default for newer users.
