### PR TITLE
deconz: Bump 5.0, Ingress fixes, Websocket support, direct access

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix Phoscon device scanning/probing triggering IP bans
 - Fix redirect to login page when Phoscon session expires
 - Fix incorrect manifest request from Phoscon frontend
+- Fix and improve API key handling with Hass.io discovery
 - Change Hass.io discovery to use add-on IP instead of hostname
 - Improve Phoscon discovery to work different and faster with Ingress
 - Add Websocket support to Ingress for instant and snappy UI updates

--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 5.0
+
+- Fix additional gateway visible on Phoscon login on Ingress
+- Fix Phoscon device scanning/probing triggering IP bans
+- Fix redirect to login page when Phoscon session expires
+- Fix incorrect manifest request from Phoscon frontend
+- Change Hass.io discovery to use add-on IP instead of hostname
+- Improve Phoscon discovery to work different and faster with Ingress
+- Add Websocket support to Ingress for instant and snappy UI updates
+- Re-instate direct access capabilities to the Phoscon/deCONZ API
+
+_Please note: This release works best with Home Assistant 0.103.4 or newer,
+that release contains fixes/optimizations for the add-on as well._
+
 ## 4.1
 
 - Change internal API port back to 40850, to prevent issue with discovery

--- a/deconz/README.md
+++ b/deconz/README.md
@@ -105,6 +105,9 @@ Some add-ons are capable of consuming the deCONZ API directly. Node-RED is
 one of those applications, that is available as an add-on, that can
 consume the deCONZ API using the `node-red-contrib-deconz` node.
 
+**WARNING** Do not use the following settings to set up a integration manually
+from within Home Assistant!
+
 To allow these add-ons to connect to deCONZ, use the following settings:
 
 - **Host**: `core-deconz`
@@ -209,17 +212,9 @@ This will ensure you have a working integration and add-on for the future.
 - Use at least 2.5A power supply for your Raspberry Pi!
   This avoids strange behavior when using this add-on.
 - The add-on has no UPnP support.
-- Home Assistant IP Ban is triggered by the add-on. This is caused by the
-  Phoscon frontend trying out many different URLs and locations to find
-  devices, triggering an IP ban in the process. We are looking into a
-  solution for this, right now, raising the number of attempts or disabling
-  IP bans in Home Assistant, is the only workaround.
 - If for some reason the deCONZ frontend does not give you an initial setup
   for your ConBee or RaspBee and keeps asking for a password, then most likely
   `delight` is the default password you can use to get in.
-- The deCONZ API is not accessible from outside the Hass.io ecosystem, no
-  direct access is provided. This cannot be enabled at this since it
-  interferes with Ingress.
 
 ## Support
 

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "4.1",
+  "version": "5.0",
   "slug": "deconz",
   "description": "Control a ZigBee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],
@@ -13,10 +13,14 @@
   "homeassistant": "0.91.2",
   "discovery": ["deconz"],
   "ports": {
-    "5900/tcp": null
+    "5900/tcp": null,
+    "8081/tcp": null,
+    "40850/tcp": null
   },
   "ports_description": {
-    "5900/tcp": "deCONZ graphical desktop via VNC"
+    "5900/tcp": "deCONZ graphical desktop via VNC",
+    "8081/tcp": "deCONZ WebSocket (Not required for Hass.io Ingress)",
+    "40850/tcp": "deCONZ API backend (Not required for Hass.io Ingress)"
   },
   "kernel_modules": true,
   "auto_uart": true,

--- a/deconz/data/discovery.sh
+++ b/deconz/data/discovery.sh
@@ -52,7 +52,7 @@ function _send_discovery() {
     serial="$(bashio::jq "${DATA_STORE}" '.serial')"
 
     config=$(bashio::var.json \
-        host "$(hostname)" \
+        host "$(bashio::addon.ip_address)" \
         port "^40850" \
         api_key "${api_key}" \
         serial "${serial}" \

--- a/deconz/data/discovery.sh
+++ b/deconz/data/discovery.sh
@@ -1,19 +1,32 @@
 #!/usr/bin/env bashio
 
-DATA_STORE="/data/hassio.json"
+DATA_STORE="/data/.local/share/dresden-elektronik/deCONZ/zll.db"
 
-
-function _deconz_api() {
+function hassio_discovery() {
     local api_key
-    local result
+    local config
+    local query
+    local retries
     local serial
 
-    # Register an API key for Home Assistant
-    if ! result="$(curl --silent --show-error --request POST -d '{"devicetype": "Home Assistant"}' "http://127.0.0.1:40850/api")"; then
-        bashio::log.debug "${result}"
-        bashio::exit.nok "Can't get API key from deCONZ gateway"
+    # Remove old discovery data storage (cleanup)
+    # We now query the deCONZ database for it directly.
+    if bashio::fs.file_exists /data/hassio.json; then
+        rm /data/hassio.json
     fi
-    api_key="$(bashio::jq "${result}" '.[0].success.username')"
+
+    # Try to get API key from deCONZ database
+    query='SELECT apikey FROM auth WHERE devicetype="Home Assistant" ORDER BY createdate DESC LIMIT 1'
+    api_key=$(sqlite3 "${DATA_STORE}" "${query}" .exit)
+    if ! bashio::var.has_value "${api_key}"; then
+        # Register an API key for Home Assistant
+        if ! result="$(curl --silent --show-error --request POST -d '{"devicetype": "Home Assistant"}' "http://127.0.0.1:40850/api")";
+        then
+            bashio::log.debug "${result}"
+            bashio::exit.nok "Can't get API key from deCONZ gateway"
+        fi
+        api_key="$(bashio::jq "${result}" '.[0].success.username')"
+    fi
 
     # Try to get the bridge ID/serial, try to avoid using 0000000000000000
     retries=25
@@ -38,19 +51,7 @@ function _deconz_api() {
         ((retries--))
     done
 
-    bashio::var.json api_key "${api_key}" serial "${serial}" > "${DATA_STORE}"
-    bashio::log.debug "Stored API information to ${DATA_STORE}"
-}
-
-
-function _send_discovery() {
-    local api_key
-    local config
-    local result
-
-    api_key="$(bashio::jq "${DATA_STORE}" '.api_key')"
-    serial="$(bashio::jq "${DATA_STORE}" '.serial')"
-
+    # Create config payload for Home Assistant
     config=$(bashio::var.json \
         host "$(bashio::addon.ip_address)" \
         port "^40850" \
@@ -64,16 +65,4 @@ function _send_discovery() {
     else
         bashio::log.error "Discovery message to Home Assistant failed!"
     fi
-}
-
-
-function hassio_discovery() {
-
-    # No API data exists - generate
-    if ! bashio::fs.file_exists "${DATA_STORE}"; then
-        bashio::log.info "Create API data for Home Assistant"
-        _deconz_api
-    fi
-
-    _send_discovery
 }

--- a/deconz/data/nginx.conf
+++ b/deconz/data/nginx.conf
@@ -37,16 +37,16 @@ http {
 
         root /dev/null;
 
-        # The websocket isn't used yet. This is a stub for the future.
-        location /api/websocket {
+        location /websocket {
             proxy_pass http://localhost:8081;
+            proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
         }
 
         location / {
-            proxy_redirect off;
             proxy_pass http://localhost:40850;
+            proxy_redirect default;
 
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -57,6 +57,32 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header Host $http_host;
             proxy_set_header X-NginX-Proxy true;
+
+            sub_filter_once off;
+            sub_filter_types *;
+            
+            # Disable Discovery from Dresden
+            sub_filter 'phoscon.de/discover' 'phoscon.de/discover_disable';
+            sub_filter 'dresden-light.appspot.com/discover' 'dresden-light.appspot.com/discover_disable';
+            sub_filter 'queryDresdenDiscovery(url){' 'queryDresdenDiscovery(url){ return Promise.resolve([]);';
+
+            # Do not probe our subnets from Ingress
+            sub_filter 'probeSubnet(ip) {' 'probeSubnet(ip) { throw new Error(\'avail\');';
+
+            # Prevent unauthenticated requests to go to Home Assistant, triggering IP bans
+            sub_filter '/api/config?_=\' + Date.now()' '%%ingress_entry%%/api/config?_=\' + Date.now()';
+
+            # Stop guessing URL's
+            sub_filter 'if (err === \'avail\')' 'if (err === \'avail\' && false)';
+
+            # Correctly handle redirect to login
+            sub_filter 'window.location.href = \'/pwa/login.html\';' 'window.location.href = \'%%ingress_entry%%/pwa/login.html\';';
+
+            # Patch Websocket support
+            sub_filter 'WebSocket(prot+host+":"+port)' 'WebSocket(prot+window.location.host+\'%%ingress_entry%%/websocket\')';
+
+            # The Manifest is useless and causes unneeded failing requests @ the Home Assistant server
+            sub_filter '<link rel="manifest" href="/pwa/manifest.json">' '';
         }
     }
 }

--- a/deconz/data/run.sh
+++ b/deconz/data/run.sh
@@ -96,6 +96,8 @@ bashio::net.wait_for 40850
 
 # Start Nginx proxy
 bashio::log.info "Starting Nginx..."
+ingress_entry=$(bashio::addon.ingress_entry)
+sed -i "s#%%ingress_entry%%#${ingress_entry}#g" /etc/nginx/nginx.conf
 nginx &
 WAIT_PIDS+=($!)
 


### PR DESCRIPTION
PR to bring a bunch of improvements to the deCONZ add-on.
I gave it a major version bump, because it adds new features.

fixes #928
fixes #941
fixes #929
fixes #942
fixes #939
fixes #937
fixes #934
fixes #930
fixes #931
fixes #926

## 5.0

- Fix additional gateway visible on Phoscon login on Ingress
- Fix Phoscon device scanning/probing triggering IP bans
- Fix redirect to login page when Phoscon session expires
- Fix incorrect manifest request from Phoscon frontend
- Fix and improve API key handling with Hass.io discovery
- Change Hass.io discovery to use add-on IP instead of hostname
- Improve Phoscon discovery to work different and faster with Ingress
- Add Websocket support to Ingress for instant and snappy UI updates
- Re-instate direct access capabilities to the Phoscon/deCONZ API

_Please note: This release works best with Home Assistant 0.103.4 or newer,
that release contains fixes/optimizations for the add-on as well. However, it is not a requirement in all cases._
