### PR TITLE
Fix missing .bash_profile on fresh install, add current path to prompt

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 8.1
+
+- Fix for non existing .bash_profile startup error
+- Add current, short, path to command line prompt
+
 ## 8.0
 
 - Add support for a web-based terminal via Ingress

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "SSH server",
-  "version": "8.0",
+  "version": "8.1",
   "slug": "ssh",
   "description": "Allows connections over SSH",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",

--- a/ssh/data/hassio.sh
+++ b/ssh/data/hassio.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-export PS1="\$ "
+export PS1="\W \$ "
 cat /etc/motd

--- a/ssh/data/run.sh
+++ b/ssh/data/run.sh
@@ -58,6 +58,7 @@ if bashio::fs.file_exists /data/.bash_profile; then
 fi
 
 # Persist .bash_profile by redirecting .bash_profile to /data
+touch /data/.bash_profile
 chmod 600 /data/.bash_profile
 ln -s -f /data/.bash_profile /root/.bash_profile
 


### PR DESCRIPTION
# Changelog

## 8.1

- Fix for non existing .bash_profile startup error
- Add current, short, path to command line prompt