### PR TITLE
Remove .git suffix from schema

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 7.8
 
 - Added support for Azure DevOps repositories by removing the requirement for the `.git` suffix
+- Update to Alpine 3.11
 
 ## 7.7
 

--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.8
+
+- Added support for Azure DevOps repositories by removing the requirement for the `.git` suffix
+
 ## 7.7
 
 - Update Hass.io CLI to 3.1.1

--- a/git_pull/README.md
+++ b/git_pull/README.md
@@ -98,7 +98,7 @@ Branch name of the Git repo. If left empty, the currently checked out branch wil
 
 ### Option: `repository` (required)
 
-Git URL to your repository (make sure to use double quotes). You have to add `.git` to your repository URL (see example configuration).
+Git URL to your repository (make sure to use double quotes).
 
 ### Option: `auto_restart` (required)
 

--- a/git_pull/build.json
+++ b/git_pull/build.json
@@ -1,10 +1,10 @@
 {
   "build_from": {
-    "aarch64": "homeassistant/aarch64-base:3.10",
-    "amd64": "homeassistant/amd64-base:3.10",
-    "armhf": "homeassistant/armhf-base:3.10",
-    "armv7": "homeassistant/armv7-base:3.10",
-    "i386": "homeassistant/i386-base:3.10"
+    "aarch64": "homeassistant/aarch64-base:3.11",
+    "amd64": "homeassistant/amd64-base:3.11",
+    "armhf": "homeassistant/armhf-base:3.11",
+    "armv7": "homeassistant/armv7-base:3.11",
+    "i386": "homeassistant/i386-base:3.11"
   },
   "args": {
     "CLI_VERSION": "3.1.1"

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -36,7 +36,7 @@
     "git_command": "match(pull|reset)",
     "git_remote": "str",
     "git_prune": "bool",
-    "repository": "match((?:.+):(//)?(.*?)(\\.git)(/?|\\#[-\\d\\w._]+?))",
+    "repository": "match((?:.+):(//)?(.*?)(\\)(/?|\\#[-\\d\\w._]+?))",
     "auto_restart": "bool",
     "restart_ignore": ["str"],
     "repeat": {

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -33,10 +33,10 @@
     "deployment_user": "str",
     "deployment_password": "str",
     "git_branch": "str",
-    "git_command": "match(pull|reset)",
+    "git_command": "list(pull|reset)",
     "git_remote": "str",
     "git_prune": "bool",
-    "repository": "match((?:.+):(//)?(.*?)(/?|\\#[-\\d\\w._]+?))",
+    "repository": "str",
     "auto_restart": "bool",
     "restart_ignore": ["str"],
     "repeat": {

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "7.7",
+  "version": "7.8",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/git_pull",

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -36,7 +36,7 @@
     "git_command": "match(pull|reset)",
     "git_remote": "str",
     "git_prune": "bool",
-    "repository": "match((?:.+):(//)?(.*?)(\\)(/?|\\#[-\\d\\w._]+?))",
+    "repository": "match((?:.+):(//)?(.*?)(/?|\\#[-\\d\\w._]+?))",
     "auto_restart": "bool",
     "restart_ignore": ["str"],
     "repeat": {


### PR DESCRIPTION
Resolves issue #629

To-do:

- [X] Creating the test environment
- Created a new Ubuntu VM on Hyper-V and installed HassOS on the VM
- Added my fork with add-ons to the HassIO instance
- [X] Removed the git suffix from schema and did a version bump to 7.8
- [X] Followed test cases from below
- [X] Updated documentation

Test cases:
- [X] Configure the add-on with an empty Azure DevOps repository: Git should create a backup of the config directory and try to pull changes from the Azure DevOps repository. It will warn the user about files that aren't available.
**Finding**: the config directory will be cleared. Even with `git_command` set to pull.
**Remark**: I have a working situation by using SSH and the deployment key. Username and password with an Azure DevOps 'Alternate credential' does not seem to work.
- [X] Upload configuration files to Azure DevOps repository: HassIO should identify new changes and pull them to the local installation
- [X] Change `git_command` from pull to reset: local changes to checked in files should be overwritten by changes in Azure DevOps repository

I used the following configuration:

````
{
  "deployment_key": [
    "-----BEGIN RSA PRIVATE KEY-----",
    "<Rest of your Private Key>"
  ],
  "deployment_key_protocol": "rsa",
  "deployment_user": "",
  "deployment_password": "",
  "git_branch": "master",
  "git_command": "pull",
  "git_remote": "origin",
  "git_prune": false,
  "repository": "<OrganizationName>@vs-ssh.visualstudio.com:v3/<OrganizationName>/<ProjectName>/<RepositoryName>",
  "auto_restart": false,
  "restart_ignore": [
    "ui-lovelace.yaml",
    ".gitignore"
  ],
  "repeat": {
    "active": false,
    "interval": 300
  }
}
````

It seems that the add-on cleans the config directory first before pulling the files from Azure DevOps. This also clears files and folders like .cloud, .storage, .HA_VERSION, home-assistant_v2.db, which (AFAIK) should not be hosted on Azure DevOps. Would you recommend to place them back afterwards or is this the desired outcome? This results in the following step-by-step instructions I can add to the documentation:
- Create a backup/copy of your configuration directory (including hidden files!) and store it somewhere save.
- Run the add-on as described in the instructions already
- Confirm that the add-on is connected to your Git server. Copy files and folders like .cloud, .storage and .HA_VERSION back to your config directory

Additionally raised an issue as the config directory is cleared when HassIO is unable to login to the repository: https://github.com/home-assistant/hassio-addons/issues/968