### PR TITLE
nginx_proxy: Add Option to disable/enable listening of IPv6

### DIFF
--- a/nginx_proxy/README.md
+++ b/nginx_proxy/README.md
@@ -49,7 +49,8 @@ Add-on configuration:
     "default": "nginx_proxy_default*.conf",
     "servers": "nginx_proxy/*.conf"
   },
-  "cloudflare": false
+  "cloudflare": false,
+  "listen_ipv6": true
 }
 ```
 
@@ -86,9 +87,15 @@ The filename(s) of the NGINX configuration for the additional servers, found in 
 If enabled, configure Nginx with a list of IP addresses directly from Cloudflare that will be used for `set_real_ip_from` directive Nginx config.
 This is so the `ip_ban_enabled` feature can be used and work correctly in /config/customize.yaml.
 
+### Option `listen_ipv6` (optional)
+
+If enabled, configure Nginx to listen on both IPv6 and IPv4. Default: Enabled
+
 ## Known issues and limitations
 
 - By default, port 80 is disabled in the add-on configuration in case the port is needed for other components or add-ons like `emulated_hue`.
+
+- Even with proper "trusted_proxies" configuration, Home Assistant may show an IP Ban/Notification that looks like an IPv6 Address. This is actually a translated IPv4 to IPv6 address. To change this functionality, set the `listen_ipv6` flag to false. This will prevent Nginx from listening to IPv6 and will translate addresses properly.
 
 ## Support
 

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -18,6 +18,7 @@
     "keyfile": "privkey.pem",
     "hsts": "max-age=31536000; includeSubDomains",
     "cloudflare": false,
+    "listen_ipv6": true,
     "customize": {
       "active": false,
       "default": "nginx_proxy_default*.conf",
@@ -30,6 +31,7 @@
     "keyfile": "str",
     "hsts": "str",
     "cloudflare": "bool",
+    "listen_ipv6": "bool",
     "customize": {
       "active": "bool",
       "default": "str",

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -51,13 +51,11 @@ fi
 if bashio::config.true 'listen_ipv6'; then
     sed -i 's/listen\ 80/listen [::]:80/g' /etc/nginx.conf
     sed -i 's/listen\ 443/listen [::]:443/g' /etc/nginx.conf
-    fi
 fi
 
 if bashio::config.false 'listen_ipv6'; then
     sed -i 's/listen\ \[\:\:\]\:80/listen 80/g' /etc/nginx.conf
     sed -i 's/listen\ \[\:\:\]\:443/listen 443/g' /etc/nginx.conf
-    fi
 fi
 
 # Prepare config file

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -48,6 +48,18 @@ if bashio::config.true 'cloudflare'; then
     fi
 fi
 
+if bashio::config.true 'listen_ipv6'; then
+    sed -i 's/listen\ 80/listen [::]:80/g' /etc/nginx.conf
+    sed -i 's/listen\ 443/listen [::]:443/g' /etc/nginx.conf
+    fi
+fi
+
+if bashio::config.false 'listen_ipv6'; then
+    sed -i 's/listen\ \[\:\:\]\:80/listen 80/g' /etc/nginx.conf
+    sed -i 's/listen\ \[\:\:\]\:443/listen 443/g' /etc/nginx.conf
+    fi
+fi
+
 # Prepare config file
 sed -i "s/%%FULLCHAIN%%/$CERTFILE/g" /etc/nginx.conf
 sed -i "s/%%PRIVKEY%%/$KEYFILE/g" /etc/nginx.conf


### PR DESCRIPTION
Even with proper configuration of "trusted_proxies", some users will see an IPv6 translated address on NGINX and Home Assistant IP Ban/Notification. This address is simply an IPv4 that has been translated, however this can cause issues with trusted_networks as well. 

The fix in this pull should add the ability to tell the NGINX instance to listen on IPv6 or to disable listening. The change is done via run.sh, with sed replacing all instances of "[::]:". However this is fully reversible by setting the flag to true if desired.

This issue has been seen here: https://github.com/home-assistant/hassio-addons/issues/471
