### PR TITLE
Fix #815

### DIFF
--- a/cec_scan/CHANGELOG.md
+++ b/cec_scan/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2
+
+- Fix a cause of "autodetect FAILED" on Raspberry Pi introduced in 2.1
+
 ## 2.1
 
 - Added README into the add-on repository

--- a/cec_scan/CHANGELOG.md
+++ b/cec_scan/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.2
 
 - Fix a cause of "autodetect FAILED" on Raspberry Pi introduced in 2.1
+- Update to Alpine 3.11
 
 ## 2.1
 

--- a/cec_scan/Dockerfile
+++ b/cec_scan/Dockerfile
@@ -27,14 +27,10 @@ RUN \
         "https://github.com/Pulse-Eight/libcec" /usr/src/libcec \
     && mkdir -p /usr/src/libcec/build \
     && cd /usr/src/libcec/build \
-    && if [[ "armhf armv7 aarch64" = *"$BUILD_ARCH"* ]]; then \
-            cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..; \
-        else \
-            cmake \
-                -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
-                -DRPI_INCLUDE_DIR=/opt/vc/include \
-                -DRPI_LIB_DIR=/opt/vc/lib ..; \
-        fi \
+    && cmake \
+        -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
+        -DRPI_INCLUDE_DIR=/opt/vc/include \
+        -DRPI_LIB_DIR=/opt/vc/lib ..; \
     && make -j$(nproc) \
     && make install \
     && apk del --no-cache .build-dependencies \

--- a/cec_scan/Dockerfile
+++ b/cec_scan/Dockerfile
@@ -30,7 +30,7 @@ RUN \
     && cmake \
         -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
         -DRPI_INCLUDE_DIR=/opt/vc/include \
-        -DRPI_LIB_DIR=/opt/vc/lib ..; \
+        -DRPI_LIB_DIR=/opt/vc/lib .. \
     && make -j$(nproc) \
     && make install \
     && apk del --no-cache .build-dependencies \

--- a/cec_scan/Dockerfile
+++ b/cec_scan/Dockerfile
@@ -27,10 +27,14 @@ RUN \
         "https://github.com/Pulse-Eight/libcec" /usr/src/libcec \
     && mkdir -p /usr/src/libcec/build \
     && cd /usr/src/libcec/build \
-    && cmake \
-        -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
-        -DRPI_INCLUDE_DIR=/opt/vc/include \
-        -DRPI_LIB_DIR=/opt/vc/lib .. \
+    && if [[ "armhf armv7 aarch64" = *"$BUILD_ARCH"* ]]; then \
+            cmake \
+                -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
+                -DRPI_INCLUDE_DIR=/opt/vc/include \
+                -DRPI_LIB_DIR=/opt/vc/lib ..; \
+        else \
+            cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..; \
+        fi \
     && make -j$(nproc) \
     && make install \
     && apk del --no-cache .build-dependencies \

--- a/cec_scan/build.json
+++ b/cec_scan/build.json
@@ -1,10 +1,10 @@
 {
   "build_from": {
-    "aarch64": "homeassistant/aarch64-base:3.10",
-    "amd64": "homeassistant/amd64-base:3.10",
-    "armhf": "homeassistant/armhf-base:3.10",
-    "armv7": "homeassistant/armv7-base:3.10",
-    "i386": "homeassistant/i386-base:3.10"
+    "aarch64": "homeassistant/aarch64-base:3.11",
+    "amd64": "homeassistant/amd64-base:3.11",
+    "armhf": "homeassistant/armhf-base:3.11",
+    "armv7": "homeassistant/armv7-base:3.11",
+    "i386": "homeassistant/i386-base:3.11"
   },
   "args": {
     "LIBCEC_VERSION": "4.0.3"

--- a/cec_scan/config.json
+++ b/cec_scan/config.json
@@ -1,6 +1,6 @@
 {
   "name": "CEC Scanner",
-  "version": "2.1",
+  "version": "2.2",
   "slug": "cec_scan",
   "description": "Scan for HDMI CEC devices",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/cec_scan",


### PR DESCRIPTION
In my testing this fixed the problem with CEC Scanner described in #815, although I'm only able to test on a Raspberry Pi 3, and I only tested the resulting container built as follows, and not in integration with hass.io itself:

`docker build --build-arg BUILD_FROM=homeassistant/armv7-base:3.10 --build-arg BUILD_ARCH=armv7 --build-arg LIBCEC_VERSION=4.0.3 .`

