### PR TITLE
nginx_proxy: Remove IPv6 Listen statements from nginx.conf

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.6
+
+- Remove ipv6 listener because we run only inside virtual network on a ipv4 range
+
+## 2.5
+
+- Migrate to Bashio
+
 ## 2.4
 
 - Added Cloudflare mechanism for creating auto-generated ipv4/ipv6 list for real visitor ip

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "NGINX Home Assistant SSL proxy",
-  "version": "2.5",
+  "version": "2.6",
   "slug": "nginx_proxy",
   "description": "An SSL/TLS proxy",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/nginx_proxy",

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -18,8 +18,8 @@ http {
 	
     server {
         server_name _;
-        listen [::]:80 default_server ipv6only=off;
-        listen [::]:443 ssl http2 default_server ipv6only=off;
+        listen 80 default_server ipv6only=off;
+        listen 443 ssl http2 default_server ipv6only=off;
         ssl_certificate /data/ssl-cert-snakeoil.pem;
         ssl_certificate_key /data/ssl-cert-snakeoil.key;
         return 444;
@@ -29,7 +29,7 @@ http {
         server_name %%DOMAIN%%;
 
         # These shouldn't need to be changed
-        listen [::]:80;
+        listen 80;
         return 301 https://$host$request_uri;
     }
 
@@ -42,7 +42,7 @@ http {
         # dhparams file
         ssl_dhparam /data/dhparams.pem;
 
-        listen [::]:443 ssl http2;
+        listen 443 ssl http2;
         %%HSTS%%
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";

--- a/nginx_proxy/data/nginx.conf
+++ b/nginx_proxy/data/nginx.conf
@@ -18,8 +18,8 @@ http {
 	
     server {
         server_name _;
-        listen 80 default_server ipv6only=off;
-        listen 443 ssl http2 default_server ipv6only=off;
+        listen 80 default_server;
+        listen 443 ssl http2 default_server;
         ssl_certificate /data/ssl-cert-snakeoil.pem;
         ssl_certificate_key /data/ssl-cert-snakeoil.key;
         return 444;


### PR DESCRIPTION
Referencing PR: https://github.com/home-assistant/hassio-addons/pull/972, making this change hard-coded, rather than an option to be set in the Addon Config.