### PR TITLE
WIP: Duck DNS IPv6 support

### DIFF
--- a/duckdns/README.md
+++ b/duckdns/README.md
@@ -71,9 +71,7 @@ IPv4 address manually.
 
 ### Option: `ipv6` (optional)
 
-By default, Duck DNS will auto detect your IPv6 address and use that.
-This option allows you to override the auto-detection and specify an
-IPv6 address manually.
+This option allows you to specify an IPv6 address to send to Duck DNS. At time of writing, they [do not support IPv6 auto detection](https://www.duckdns.org/faqs.jsp), so this value needs to be set in order for the assignment to work. This value is `eval`ed by the shell, so you can use its command substitution here to get the address programmatically.
 
 ### Option: `token`
 

--- a/duckdns/README.md
+++ b/duckdns/README.md
@@ -73,6 +73,8 @@ IPv4 address manually.
 
 This option allows you to specify an IPv6 address to send to Duck DNS. At time of writing, they [do not support IPv6 auto detection](https://www.duckdns.org/faqs.jsp), so this value needs to be set in order for the assignment to work. This value is `eval`ed by the shell, so you can use its command substitution here to get the address programmatically.
 
+Default value: `$(curl -6s -m 10 https://api6.ipify.org)`, set to `""` to disable trying this.
+
 ### Option: `token`
 
 The DuckDNS authentication token found at the top of the DuckDNS account landing page. The token is required to make any changes to the subdomains registered to your account.

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -50,7 +50,7 @@ fi
 
 # Run duckdns
 while true; do
-    if answer="$(curl -sk "https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ip=${IPV4}&ipv6=${IPV6}&verbose=true")"; then
+    if answer="$(curl -sk "https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ip=${IPV4}&ipv6=$(eval printf %s \"${IPV6}\")&verbose=true")"; then
         bashio::log.info "${answer}"
     else
         bashio::log.warning "${answer}"

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -8,7 +8,7 @@ LE_UPDATE="0"
 
 # DuckDNS
 IPV4=$(bashio::config 'ipv4 // empty')
-IPV6=$(bashio::config 'ipv6 // empty')
+IPV6=$(bashio::config 'ipv6 // "$(curl -6s -m 10 https://api6.ipify.org)"')
 TOKEN=$(bashio::config 'token')
 DOMAINS=$(bashio::config 'domains | join(",")')
 WAIT_TIME=$(bashio::config 'seconds')


### PR DESCRIPTION
One idea/way how to support IPv6 in Duck DNS here.

WIP: This doesn't actually work yet, because addon_core_duckdns container doesn't have IPv6 configured in it, so the curl call won't produce anything. Haven't looked closer into it, but I suppose it would be possible to enable IPv6 in it somehow, because for example the setup where I ssh into using the community ssh addon has it.

Another WIP item is that `-k` should be removed from the duckdns API call like in #1018, not done here to avoid conflict.