### PR TITLE
Rewrite MariaDB add-on

### DIFF
--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.0
+
+- Pin add-on to Alpine Linux 3.11
+- Redirect MariaDB error log to add-on logs
+- Remove grant & host options
+- Add support for the mysql service
+- Use a more secure default on install
+- Skip DNS name resolving
+- Improve integrity checks and recovery
+- Tune MariaDB for lower memory usage
+
 ## 1.3
 
 - Update from bash to bashio

--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Skip DNS name resolving
 - Improve integrity checks and recovery
 - Tune MariaDB for lower memory usage
+- Close port 3306 by default
+- Ensure a proper collation set is used
+- Adds database upgrade process during startup
+- Change default configuration username from "hass" to "homeassistant"
 
 ## 1.3
 

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -5,7 +5,10 @@ FROM $BUILD_FROM
 ENV LANG C.UTF-8
 
 # Setup base
-RUN apk add --no-cache mariadb mariadb-client
+RUN apk add --no-cache \
+    mariadb \
+    mariadb-client \
+    pwgen
 
 # Copy data
 COPY data/run.sh /

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -8,6 +8,7 @@ ENV LANG C.UTF-8
 RUN apk add --no-cache \
     mariadb \
     mariadb-client \
+    mariadb-server-utils \
     pwgen
 
 # Copy data

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -35,13 +35,10 @@ databases:
   - homeassistant
 logins:
   - username: hass
-    host: "%"
-    password: 
+    password: PASSWORD
 rights:
   - username: hass
-    host: "%"
     database: homeassistant
-    grant: ALL PRIVILEGES ON
 ```
 
 ### Option: `databases` (required)
@@ -56,10 +53,6 @@ This section defines a create user definition in MariaDB. [Create User][createus
 
 Database user login, e.g., `hass`. [User Name][username] documentation.
 
-### Option: `logins.host` (required)
-
-Hostname allowed to connect to database. [Host Name][hostname] documentation.
-
 ### Option: `logins.password` (required)
 
 Password for user login. This should be strong and unique.
@@ -72,17 +65,9 @@ This section grant privileges to users in MariaDB. [Grant][grant] documentation.
 
 This should be the same user name defined in `logins` -> `username`.
 
-### Option: `rights.host` (required)
-
-This should be the same hostname defined in `logins` -> `host`.
-
 ### Option: `rights.database` (required)
 
 This should be the same database defined in `databases`.
-
-### Option: `rights.grant` (required)
-
-This is the grant statement giving your user access to the database.
 
 ## Home Assistant Configuration
 

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -34,10 +34,10 @@ Example add-on configuration:
 databases:
   - homeassistant
 logins:
-  - username: hass
+  - username: homeassistant
     password: PASSWORD
 rights:
-  - username: hass
+  - username: homeassistant
     database: homeassistant
 ```
 
@@ -51,7 +51,7 @@ This section defines a create user definition in MariaDB. [Create User][createus
 
 ### Option: `logins.username` (required)
 
-Database user login, e.g., `hass`. [User Name][username] documentation.
+Database user login, e.g., `homeassistant`. [User Name][username] documentation.
 
 ### Option: `logins.password` (required)
 
@@ -77,7 +77,7 @@ Example Home Assistant configuration:
 
 ```yaml
 recorder:
-  db_url: mysql://hass:password@core-mariadb/homeassistant?charset=utf8
+  db_url: mysql://homeassistant:password@core-mariadb/homeassistant?charset=utf8
 ```
 
 ## Support

--- a/mariadb/build.json
+++ b/mariadb/build.json
@@ -1,0 +1,9 @@
+{
+  "build_from": {
+    "aarch64": "homeassistant/aarch64-base:3.11",
+    "amd64": "homeassistant/amd64-base:3.11",
+    "armhf": "homeassistant/armhf-base:3.11",
+    "armv7": "homeassistant/armv7-base:3.11",
+    "i386": "homeassistant/i386-base:3.11"
+  }
+}

--- a/mariadb/config.json
+++ b/mariadb/config.json
@@ -1,6 +1,6 @@
 {
   "name": "MariaDB",
-  "version": "1.3",
+  "version": "2.0",
   "slug": "mariadb",
   "description": "An SQL database server",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/mariadb",

--- a/mariadb/config.json
+++ b/mariadb/config.json
@@ -9,7 +9,7 @@
   "boot": "auto",
   "services": ["mysql:provide"],
   "ports": {
-    "3306/tcp": 3306
+    "3306/tcp": null
   },
   "options": {
     "databases": ["homeassistant"],

--- a/mariadb/config.json
+++ b/mariadb/config.json
@@ -7,6 +7,7 @@
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "system",
   "boot": "auto",
+  "services": ["mysql:provide"],
   "ports": {
     "3306/tcp": 3306
   },

--- a/mariadb/config.json
+++ b/mariadb/config.json
@@ -13,10 +13,10 @@
   },
   "options": {
     "databases": ["homeassistant"],
-    "logins": [{ "username": "hass", "password": null }],
+    "logins": [{ "username": "homeassistant", "password": null }],
     "rights": [
       {
-        "username": "hass",
+        "username": "homeassistant",
         "database": "homeassistant"
       }
     ]

--- a/mariadb/config.json
+++ b/mariadb/config.json
@@ -12,22 +12,18 @@
   },
   "options": {
     "databases": ["homeassistant"],
-    "logins": [{ "username": "hass", "host": "%", "password": null }],
+    "logins": [{ "username": "hass", "password": null }],
     "rights": [
       {
         "username": "hass",
-        "host": "%",
-        "database": "homeassistant",
-        "grant": "ALL PRIVILEGES ON"
+        "database": "homeassistant"
       }
     ]
   },
   "schema": {
     "databases": ["str"],
-    "logins": [{ "username": "str", "host": "str", "password": "str" }],
-    "rights": [
-      { "username": "str", "host": "str", "database": "str", "grant": "str" }
-    ]
+    "logins": [{ "username": "str", "password": "str" }],
+    "rights": [{ "username": "str", "database": "str" }]
   },
   "image": "homeassistant/{arch}-addon-mariadb",
   "timeout": 20

--- a/mariadb/data/mariadb-server.cnf
+++ b/mariadb/data/mariadb-server.cnf
@@ -1,5 +1,6 @@
 [mysqld]
 port=3306
+log_error=mariadb.err
 
 # Persistent storage location
 datadir=/data/databases

--- a/mariadb/data/mariadb-server.cnf
+++ b/mariadb/data/mariadb-server.cnf
@@ -5,6 +5,10 @@ log_error=mariadb.err
 # Persistent storage location
 datadir=/data/databases
 
+# Use a proper collation set
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+
 # Do not resolve DNS names
 skip-name-resolve
 

--- a/mariadb/data/mariadb-server.cnf
+++ b/mariadb/data/mariadb-server.cnf
@@ -1,11 +1,35 @@
+[mysqld]
+port=3306
 
-[server]
+# Persistent storage location
+datadir=/data/databases
 
 # Do not resolve DNS names
 skip-name-resolve
 
-datadir=/data/databases
+# Tune for low-end devices (Like a Raspberry Pi)
+key_buffer_size = 16M
+max_connections = 64
+myisam_recover_options = FORCE
+myisam_sort_buffer_size = 8M
+net_buffer_length = 16K
+read_buffer_size = 256K
+read_rnd_buffer_size = 512K
+sort_buffer_size = 512K
+join_buffer_size = 128K
+table_open_cache = 64
+thread_cache_size = 8
+thread_stack = 192K
+tmp_table_size = 16M
 
-[galera]
+# Disable query cache
+query_cache_limit = 1M
+query_cache_size = 0M
+query_cache_type = 0
 
-[mariadb]
+# InnoDB Tweaks
+innodb_buffer_pool_instances = 1
+innodb_buffer_pool_size = 64M
+innodb_log_buffer_size = 8M
+innodb_log_file_size = 48M
+max_binlog_size = 96M

--- a/mariadb/data/mariadb-server.cnf
+++ b/mariadb/data/mariadb-server.cnf
@@ -1,7 +1,8 @@
 
 [server]
 
-[mysqld]
+# Do not resolve DNS names
+skip-name-resolve
 
 datadir=/data/databases
 

--- a/mariadb/data/run.sh
+++ b/mariadb/data/run.sh
@@ -19,7 +19,7 @@ ln -s /proc/1/fd/1 /data/databases/local-mariadb.err
 
 # Start mariadb
 bashio::log.info "Starting MariaDB"
-mysqld_safe --datadir="$MARIADB_DATA" --user=root --skip-log-bin < /dev/null &
+mysqld_safe --datadir="$MARIADB_DATA" --user=root < /dev/null &
 MARIADB_PID=$!
 
 # Wait until DB is running
@@ -28,6 +28,11 @@ while ! mysql -e "" 2> /dev/null; do
 done
 
 bashio::log.info "Check data integrity and fix corruptions"
+mysqlcheck --no-defaults --databases mysql --fix-db-names --fix-table-names || true
+mysqlcheck --no-defaults --databases mysql --check --check-upgrade --auto-repair || true
+mysqlcheck --no-defaults --all-databases --skip-database=mysql --fix-db-names --fix-table-names || true
+mysqlcheck --no-defaults --all-databases --skip-database=mysql --check --check-upgrade --auto-repair || true
+
 # Set default secure values after inital setup
 if bashio::var.true "${NEW_INSTALL}"; then
     # Secure the installation.

--- a/mariadb/data/run.sh
+++ b/mariadb/data/run.sh
@@ -38,17 +38,16 @@ for line in $(bashio::config "databases"); do
 done
 
 # Init logins
-bashio::log.info "Init/Update users"
+bashio::log.info "Ensure users exists and are updated"
 for login in $(bashio::config "logins|keys"); do
     USERNAME=$(bashio::config "logins[${login}].username")
     PASSWORD=$(bashio::config "logins[${login}].password")
-    HOST=$(bashio::config "logins[${login}].host")
 
-    if mysql -e "SET PASSWORD FOR '$USERNAME'@'$HOST' = PASSWORD('$PASSWORD');" 2> /dev/null; then
-        bashio::log.info "Update user $USERNAME"
+    if mysql -e "SET PASSWORD FOR '${USERNAME}'@'%' = PASSWORD('${PASSWORD}');" 2> /dev/null; then
+        bashio::log.info "Update user ${USERNAME}"
     else
-        bashio::log.info "Create user $USERNAME"
-        mysql -e "CREATE USER '$USERNAME'@'$HOST' IDENTIFIED BY '$PASSWORD';" 2> /dev/null || true
+        bashio::log.info "Create user ${USERNAME}"
+        mysql -e "CREATE USER '${USERNAME}'@'%' IDENTIFIED BY '${PASSWORD}';" 2> /dev/null || true
     fi
 done
 
@@ -56,12 +55,10 @@ done
 bashio::log.info "Init/Update rights"
 for right in $(bashio::config "rights|keys"); do
     USERNAME=$(bashio::config "rights[${right}].username")
-    HOST=$(bashio::config "rights[${right}].host")
     DATABASE=$(bashio::config "rights[${right}].database")
-    GRANT=$(bashio::config "rights[${right}].grant")
 
-    bashio::log.info "Alter rights for $USERNAME@$HOST - $DATABASE"
-    mysql -e "GRANT $GRANT $DATABASE.* TO '$USERNAME'@'$HOST';" 2> /dev/null || true
+    bashio::log.info "Alter rights for ${USERNAME} to ${DATABASE}"
+    mysql -e "GRANT ALL PRIVILEGES ${DATABASE}.* TO '${USERNAME}'@'%';" 2> /dev/null || true
 done
 
 # Register stop

--- a/mariadb/data/run.sh
+++ b/mariadb/data/run.sh
@@ -7,7 +7,7 @@ NEW_INSTALL=false
 # Init mariadb
 if ! bashio::fs.directory_exists "${MARIADB_DATA}"; then
     bashio::log.info "Create a new mariadb initial system"
-    mysql_install_db --user=root --datadir="$MARIADB_DATA" > /dev/null
+    mysql_install_db --user=root --datadir="$MARIADB_DATA" --skip-name-resolve --skip-test-db > /dev/null
     NEW_INSTALL=true
 else
     bashio::log.info "Using existing mariadb initial system"

--- a/mariadb/data/run.sh
+++ b/mariadb/data/run.sh
@@ -11,6 +11,10 @@ else
     bashio::log.info "Using existing mariadb initial system"
 fi
 
+# Redirect log output
+rm -f /data/databases/local-mariadb.err
+ln -s /proc/1/fd/1 /data/databases/local-mariadb.err
+
 # Start mariadb
 bashio::log.info "Starting MariaDB"
 mysqld_safe --datadir="$MARIADB_DATA" --user=root --skip-log-bin < /dev/null &

--- a/mariadb/data/run.sh
+++ b/mariadb/data/run.sh
@@ -14,8 +14,8 @@ else
 fi
 
 # Redirect log output
-rm -f /data/databases/local-mariadb.err
-ln -s /proc/1/fd/1 /data/databases/local-mariadb.err
+rm -f /data/databases/mariadb.err
+ln -s /proc/1/fd/1 /data/databases/mariadb.err
 
 # Start mariadb
 bashio::log.info "Starting MariaDB"

--- a/mariadb/data/run.sh
+++ b/mariadb/data/run.sh
@@ -81,7 +81,7 @@ for right in $(bashio::config "rights|keys"); do
     DATABASE=$(bashio::config "rights[${right}].database")
 
     bashio::log.info "Alter rights for ${USERNAME} to ${DATABASE}"
-    mysql -e "GRANT ALL PRIVILEGES ${DATABASE}.* TO '${USERNAME}'@'%';" 2> /dev/null || true
+    mysql -e "GRANT ALL PRIVILEGES ON ${DATABASE}.* TO '${USERNAME}'@'%';" 2> /dev/null || true
 done
 
 # Generate service user

--- a/mariadb/data/run.sh
+++ b/mariadb/data/run.sh
@@ -7,7 +7,7 @@ NEW_INSTALL=false
 # Init mariadb
 if ! bashio::fs.directory_exists "${MARIADB_DATA}"; then
     bashio::log.info "Create a new mariadb initial system"
-    mysql_install_db --user=root --datadir="$MARIADB_DATA" --skip-name-resolve --skip-test-db > /dev/null
+    mysql_install_db --user=root --datadir="${MARIADB_DATA}" --skip-name-resolve --skip-test-db > /dev/null
     NEW_INSTALL=true
 else
     bashio::log.info "Using existing mariadb initial system"
@@ -19,7 +19,7 @@ ln -s /proc/1/fd/1 /data/databases/local-mariadb.err
 
 # Start mariadb
 bashio::log.info "Starting MariaDB"
-mysqld_safe --datadir="$MARIADB_DATA" --user=root < /dev/null &
+mysqld_safe --datadir="${MARIADB_DATA}" --user=root < /dev/null &
 MARIADB_PID=$!
 
 # Wait until DB is running
@@ -54,10 +54,10 @@ EOSQL
 fi
 
 # Init databases
-bashio::log.info "Init custom database"
-for line in $(bashio::config "databases"); do
-    bashio::log.info "Create database $line"
-    mysql -e "CREATE DATABASE $line;" 2> /dev/null || true
+bashio::log.info "Ensure databases exists"
+for database in $(bashio::config "databases"); do
+    bashio::log.info "Create database ${database}"
+    mysql -e "CREATE DATABASE ${database};" 2> /dev/null || true
 done
 
 # Init logins
@@ -118,4 +118,4 @@ function stop_mariadb() {
 }
 trap "stop_mariadb" SIGTERM SIGHUP
 
-wait "$MARIADB_PID"
+wait "${MARIADB_PID}"

--- a/mariadb/data/run.sh
+++ b/mariadb/data/run.sh
@@ -33,6 +33,9 @@ mysqlcheck --no-defaults --databases mysql --check --check-upgrade --auto-repair
 mysqlcheck --no-defaults --all-databases --skip-database=mysql --fix-db-names --fix-table-names || true
 mysqlcheck --no-defaults --all-databases --skip-database=mysql --check --check-upgrade --auto-repair || true
 
+bashio::log.info "Ensuring internal database upgrades are performed"
+mysql_upgrade --silent
+
 # Set default secure values after inital setup
 if bashio::var.true "${NEW_INSTALL}"; then
     # Secure the installation.


### PR DESCRIPTION
## 2.0

- Pin add-on to Alpine Linux 3.11
- Redirect MariaDB error log to add-on logs (less writes to disk)
- Remove grant & host options
- Add support for the mysql service
- Use a more secure default on install
- Skip DNS name resolving
- Improve integrity checks and recovery
- Tune MariaDB for lower memory usage


ℹ️ The tuning is done, because in theory, MariaDB was allowed to use 7.2Gb of memory... This should limit it around max 150-200Mb, while still performing nicely. We might need to tune this more in the future, depends a bit on actual production experience.

ℹ️ The bin log has been enabled again, to improve recovery functionality (at the cost of more disk writes).

**⚠️ This is a big change, we need to test this!**


The output of logs:

![image](https://user-images.githubusercontent.com/195327/74240819-009c1800-4cdb-11ea-90a5-17961492eeb3.png)
