### PR TITLE
duckdns: add option to grab IP addresses from URLs

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.12
+
+- Add option to specify a service or file URL as IPv4 and IPv6 address source
+
 ## 1.11
 
 - Do not skip TLS security checks on Duck DNS API access

--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.12
 
-- Add option to specify a service or file URL as IPv4 and IPv6 address source
+- Add option to specify a service or URL as IPv4 and IPv6 address source
 
 ## 1.11
 

--- a/duckdns/README.md
+++ b/duckdns/README.md
@@ -67,11 +67,20 @@ By default, Duck DNS will auto detect your IPv4 address and use that.
 This option allows you to override the auto-detection and specify an
 IPv4 address manually.
 
+If you specify a URL here, contents of the resource it points to will be
+fetched and used as the address. This enables getting the address using
+a service like https://api4.ipify.org/ or https://ipv4.wtfismyip.com/text
+or from a local `file:/` URL.
+
 ### Option: `ipv6` (optional)
 
 By default, Duck DNS will auto detect your IPv6 address and use that.
 This option allows you to override the auto-detection and specify an
 IPv6 address manually.
+
+If you specify a URL here, contents of the resource it points to will be
+fetched and used as the address. This enables getting the address from
+an external service or from a local `file:/` URL.
 
 ### Option: `token`
 
@@ -89,6 +98,17 @@ The number of seconds to wait before updating DuckDNS subdomains and renewing Le
 
 - To log in, DuckDNS requires a free account from any of the following services: Google, Github, Twitter, Persona or Reddit.
 - A free DuckDNS account is limited to five subdomains.
+- At time of writing, Duck DNS' own IPv6 autodetection
+  [does not actually work][duckdns-faq], but you can use the URL option
+  for `ipv6` to get around this, read on.
+- IPv6 IP address detection service URLs are likely to not work for the time
+  being, because the add-on is run in a container without IPv6 connectivity.
+  IPv4 services that provide the IPv6 address do work, as well as pointing to a
+  local `file:/` URL. You can for example create a script that gets the IPv6
+  address and writes it to `/share/my-ipv6.txt` periodically using `cron`
+  with the [Community SSH add-on][community-ssh-addon] which can have IPv6
+  connectivity, and have this add-on use it by specifying
+  `"ipv6": "file:///share/my-ipv6.txt"`
 
 ## Support
 
@@ -112,3 +132,5 @@ In case you've found a bug, please [open an issue on our GitHub][issue].
 [issue]: https://github.com/home-assistant/hassio-addons/issues
 [reddit]: https://reddit.com/r/homeassistant
 [duckdns]: https://duckdns.org
+[duckdns-faq]: https://www.duckdns.org/faqs.jsp
+[community-ssh-addon]: https://github.com/hassio-addons/addon-ssh

--- a/duckdns/README.md
+++ b/duckdns/README.md
@@ -70,7 +70,6 @@ IPv4 address manually.
 If you specify a URL here, contents of the resource it points to will be
 fetched and used as the address. This enables getting the address using
 a service like https://api4.ipify.org/ or https://ipv4.wtfismyip.com/text
-or from a local `file:/` URL.
 
 ### Option: `ipv6` (optional)
 
@@ -79,8 +78,8 @@ This option allows you to override the auto-detection and specify an
 IPv6 address manually.
 
 If you specify a URL here, contents of the resource it points to will be
-fetched and used as the address. This enables getting the address from
-an external service or from a local `file:/` URL.
+fetched and used as the address. This enables getting the address using
+a service like https://api6.ipify.org/ or https://ipv6.wtfismyip.com/text
 
 ### Option: `token`
 
@@ -101,14 +100,6 @@ The number of seconds to wait before updating DuckDNS subdomains and renewing Le
 - At time of writing, Duck DNS' own IPv6 autodetection
   [does not actually work][duckdns-faq], but you can use the URL option
   for `ipv6` to get around this, read on.
-- IPv6 IP address detection service URLs are likely to not work for the time
-  being, because the add-on is run in a container without IPv6 connectivity.
-  IPv4 services that provide the IPv6 address do work, as well as pointing to a
-  local `file:/` URL. You can for example create a script that gets the IPv6
-  address and writes it to `/share/my-ipv6.txt` periodically using `cron`
-  with the [Community SSH add-on][community-ssh-addon] which can have IPv6
-  connectivity, and have this add-on use it by specifying
-  `"ipv6": "file:///share/my-ipv6.txt"`
 
 ## Support
 
@@ -133,4 +124,3 @@ In case you've found a bug, please [open an issue on our GitHub][issue].
 [reddit]: https://reddit.com/r/homeassistant
 [duckdns]: https://duckdns.org
 [duckdns-faq]: https://www.duckdns.org/faqs.jsp
-[community-ssh-addon]: https://github.com/hassio-addons/addon-ssh

--- a/duckdns/config.json
+++ b/duckdns/config.json
@@ -7,7 +7,7 @@
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "services",
   "boot": "auto",
-  "map": ["ssl:rw"],
+  "map": ["ssl:rw", "share:ro"],
   "options": {
     "lets_encrypt": {
       "accept_terms": false,

--- a/duckdns/config.json
+++ b/duckdns/config.json
@@ -1,13 +1,13 @@
 {
   "name": "Duck DNS",
-  "version": "1.10",
+  "version": "1.11",
   "slug": "duckdns",
   "description": "Free Dynamic DNS (DynDNS or DDNS) service with Let's Encrypt support",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/duckdns",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "services",
   "boot": "auto",
-  "map": ["ssl:rw", "share:ro"],
+  "map": ["ssl:rw"],
   "options": {
     "lets_encrypt": {
       "accept_terms": false,

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -50,7 +50,11 @@ fi
 
 # Run duckdns
 while true; do
-    if answer="$(curl -s "https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ip=${IPV4}&ipv6=${IPV6}&verbose=true")"; then
+
+    [[ ${IPV4} != *:/* ]] && ipv4=${IPV4} || ipv4=$(curl -s -m 10 "${IPV4}")
+    [[ ${IPV6} != *:/* ]] && ipv6=${IPV6} || ipv6=$(curl -s -m 10 "${IPV6}")
+
+    if answer="$(curl -s "https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ip=${ipv4}&ipv6=${ipv6}&verbose=true")"; then
         bashio::log.info "${answer}"
     else
         bashio::log.warning "${answer}"


### PR DESCRIPTION
Enables use of external services instead of Duck DNS' automatic detection, which at time of writing doesn't work with IPv6: https://www.duckdns.org/faqs.jsp

Supersedes #1019. I chose to amend/use the existing ipv4 and ipv6 config options because adding a separate `ipvx_manual` like suggested there would IMO resulted in clunky config and docs.

Also improves on #892