### PR TITLE
Bump deCONZ to 2.05.73

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.2
+
+- Bump deCONZ to 2.05.73
+- Small adjustments to NGINX configuration
+
 ## 5.1
 
 - Add LEDVANCE / OSRAM otau firmware downloader, respecting max 10 DL per minute Ratelimits

--- a/deconz/build.json
+++ b/deconz/build.json
@@ -5,6 +5,6 @@
     "armhf": "homeassistant/armhf-base-raspbian:stretch"
   },
   "args": {
-    "DECONZ_VERSION": "2.05.72"
+    "DECONZ_VERSION": "2.05.73"
   }
 }

--- a/deconz/data/nginx.conf
+++ b/deconz/data/nginx.conf
@@ -15,7 +15,6 @@ http {
     proxy_read_timeout  1200;
     gzip                on;
     gzip_disable        "msie6";
-    resolver            127.0.0.11;
 
     map $http_upgrade $connection_upgrade {
         default upgrade;
@@ -38,14 +37,14 @@ http {
         root /dev/null;
 
         location /websocket {
-            proxy_pass http://localhost:8081;
+            proxy_pass http://127.0.0.1:8081;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
         }
 
         location / {
-            proxy_pass http://localhost:40850;
+            proxy_pass http://127.0.0.1:40850;
             proxy_redirect default;
 
             proxy_http_version 1.1;


### PR DESCRIPTION
## 5.2

- Bump deCONZ to 2.05.73
- Small adjustments to NGINX configuration

closes #1087