### PR TITLE
configurator: Name change to File editor

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3
+
+- Visual name change, the "Configurator", is now called the "File editor".
+
 ## 4.2
 
 - Fixes an issue with the dirs first option

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,8 +1,8 @@
 {
-  "name": "Configurator",
-  "version": "4.2",
+  "name": "File editor",
+  "version": "4.3",
   "slug": "configurator",
-  "description": "Browser-based configuration file editor for Home Assistant",
+  "description": "Simple browser-based file editor for Home Assistant",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/configurator",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "homeassistant": "0.91.1",


### PR DESCRIPTION
A visual name change, the "Configurator", is now called the "File editor".

This to make a better distinction between editing files and configuring Home Assistant.