### PR TITLE
Re-enable ssh add-on's network ssh access.

### DIFF
--- a/ssh/config.json
+++ b/ssh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Terminal & SSH",
-  "version": "8.4",
+  "version": "8.5",
   "slug": "ssh",
   "description": "Allow logging in remotely to Home Assistant using SSH",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",
@@ -15,7 +15,7 @@
   "hassio_role": "manager",
   "auto_uart": true,
   "ports": {
-    "22/tcp": null
+    "22/tcp": 22
   },
   "map": ["config:rw", "ssl:rw", "addons:rw", "share:rw", "backup:rw"],
   "options": {


### PR DESCRIPTION
PR #1117 disabled SSH network access for the SSH server add-on.  

Users who previous had the "SSH Server" official add-on installed, will be surprised when they update to version 8.4 that ssh access from the network suddenly stops working.

PR #1117 has effectively changed this add-on from something that enabled ssh access over the network into something that only provides access through a web GUI terminal.

This PR simply makes ssh enabled be default restoring the previous behavior to avoid frustrating existing users.

If the intent is to have SSH network access disabled by default. it should be better communicated as a breaking change in a future PR.  There are a number of ways this could be done. At a minimum documentation updates and possibly advertising it as a breaking change in a future version.