### PR TITLE
Fix certificate request logic

### DIFF
--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -124,6 +124,7 @@ else
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store
+# shellcheck disable=SC2012
 CERT_DIR_LATEST="$(ls -td $CERT_DIR/live/*/ | head -1)"
 cp "${CERT_DIR_LATEST}privkey.pem" "/ssl/$KEYFILE"
 cp "${CERT_DIR_LATEST}fullchain.pem" "/ssl/$CERTFILE"

--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -124,6 +124,6 @@ else
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store
-CERT_DIR=$(find $CERT_DIR/live/* -type d -maxdepth 1 | awk '{ "stat -c '%Y' "$0 | getline ts; printf "%d\t%s\n", ts, $0 }' | sort -nk1 | tail -1 | awk '{ print $2 }')
+CERT_DIR="$(realpath(ls -td $CERT_DIR/live/*/ | head -1))"
 cp "$CERT_DIR"/privkey.pem "/ssl/$KEYFILE"
 cp "$CERT_DIR"/fullchain.pem "/ssl/$CERTFILE"

--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -123,6 +123,7 @@ else
         --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" --standalone
 fi
 
-# copy certs to store
-cp "$CERT_DIR"/live/*/privkey.pem "/ssl/$KEYFILE"
-cp "$CERT_DIR"/live/*/fullchain.pem "/ssl/$CERTFILE"
+# Get the last modified cert directory and copy the cert and private key to store
+CERT_DIR=$(ls -td $CERT_DIR/live/* | head -1)
+cp "$CERT_DIR"/privkey.pem "/ssl/$KEYFILE"
+cp "$CERT_DIR"/fullchain.pem "/ssl/$CERTFILE"

--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -124,6 +124,6 @@ else
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store
-CERT_DIR=$(realpath $(ls -td $CERT_DIR/live/*/ | head -1))
+CERT_DIR=$(realpath "$(ls -td $CERT_DIR/live/*/ | head -1)")
 cp "$CERT_DIR"/privkey.pem "/ssl/$KEYFILE"
 cp "$CERT_DIR"/fullchain.pem "/ssl/$CERTFILE"

--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -124,6 +124,6 @@ else
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store
-CERT_DIR=$(realpath "$(ls -td $CERT_DIR/live/*/ | head -1)")
+CERT_DIR=$(find $CERT_DIR/live/* -type d -maxdepth 1 | awk '{ "stat -c '%Y' "$0 | getline ts; if (ts >= ots) printf "%d\t%s\n", ts, $0; ots=ts; }' | sort -k1 | tail -1 | awk '{ print $2 }')
 cp "$CERT_DIR"/privkey.pem "/ssl/$KEYFILE"
 cp "$CERT_DIR"/fullchain.pem "/ssl/$CERTFILE"

--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -124,6 +124,6 @@ else
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store
-CERT_DIR=$(realpath(ls -td $CERT_DIR/live/*/ | head -1))
+CERT_DIR=$(realpath $(ls -td $CERT_DIR/live/*/ | head -1))
 cp "$CERT_DIR"/privkey.pem "/ssl/$KEYFILE"
 cp "$CERT_DIR"/fullchain.pem "/ssl/$CERTFILE"

--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -124,6 +124,6 @@ else
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store
-CERT_DIR=$(ls -td $CERT_DIR/live/* | head -1)
+CERT_DIR=$(realpath(ls -td $CERT_DIR/live/*/ | head -1))
 cp "$CERT_DIR"/privkey.pem "/ssl/$KEYFILE"
 cp "$CERT_DIR"/fullchain.pem "/ssl/$CERTFILE"

--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -124,6 +124,6 @@ else
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store
-CERT_DIR=$(find $CERT_DIR/live/* -type d -maxdepth 1 | awk '{ "stat -c '%Y' "$0 | getline ts; if (ts >= ots) printf "%d\t%s\n", ts, $0; ots=ts; }' | sort -nk1 | tail -1 | awk '{ print $2 }')
+CERT_DIR=$(find $CERT_DIR/live/* -type d -maxdepth 1 | awk '{ "stat -c '%Y' "$0 | getline ts; printf "%d\t%s\n", ts, $0 }' | sort -nk1 | tail -1 | awk '{ print $2 }')
 cp "$CERT_DIR"/privkey.pem "/ssl/$KEYFILE"
 cp "$CERT_DIR"/fullchain.pem "/ssl/$CERTFILE"

--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -124,6 +124,6 @@ else
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store
-CERT_DIR="$(realpath(ls -td $CERT_DIR/live/*/ | head -1))"
-cp "$CERT_DIR"/privkey.pem "/ssl/$KEYFILE"
-cp "$CERT_DIR"/fullchain.pem "/ssl/$CERTFILE"
+CERT_DIR_LATEST="$(ls -td $CERT_DIR/live/*/ | head -1)"
+cp "${CERT_DIR_LATEST}privkey.pem" "/ssl/$KEYFILE"
+cp "${CERT_DIR_LATEST}fullchain.pem" "/ssl/$CERTFILE"

--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -124,6 +124,6 @@ else
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store
-CERT_DIR=$(find $CERT_DIR/live/* -type d -maxdepth 1 | awk '{ "stat -c '%Y' "$0 | getline ts; if (ts >= ots) printf "%d\t%s\n", ts, $0; ots=ts; }' | sort -k1 | tail -1 | awk '{ print $2 }')
+CERT_DIR=$(find $CERT_DIR/live/* -type d -maxdepth 1 | awk '{ "stat -c '%Y' "$0 | getline ts; if (ts >= ots) printf "%d\t%s\n", ts, $0; ots=ts; }' | sort -nk1 | tail -1 | awk '{ print $2 }')
 cp "$CERT_DIR"/privkey.pem "/ssl/$KEYFILE"
 cp "$CERT_DIR"/fullchain.pem "/ssl/$CERTFILE"

--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -103,21 +103,24 @@ else
     PROVIDER_ARGUMENTS+=("--${DNS_PROVIDER}" "--${DNS_PROVIDER}-credentials" /data/dnsapikey)
 fi
 
-# Generate new certs
-if [ ! -d "$CERT_DIR/live" ]; then
-    DOMAIN_ARR=()
-    for line in $DOMAINS; do
-        DOMAIN_ARR+=(-d "$line")
-    done
+# Gather all domains into a plaintext file
+DOMAIN_ARR=()
+for line in $DOMAINS; do
+    DOMAIN_ARR+=(-d "$line")
+done
+echo "$DOMAINS" > /data/domains.gen
 
-    echo "$DOMAINS" > /data/domains.gen
-    if [ "$CHALLENGE" == "dns" ]; then
-        certbot certonly --non-interactive --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" "${PROVIDER_ARGUMENTS[@]}" --email "$EMAIL" --agree-tos --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}"
-    else
-        certbot certonly --non-interactive --standalone --email "$EMAIL" --agree-tos --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}"
-    fi
+# Generate a new certificate if necessary or expand a previous certificate if domains has changed
+if [ "$CHALLENGE" == "dns" ]; then
+    certbot certonly --non-interactive --keep-until-expiring --expand \
+        --email "$EMAIL" --agree-tos \
+        --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
+        --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" "${PROVIDER_ARGUMENTS[@]}"
 else
-    certbot renew --non-interactive --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" --preferred-challenges "$CHALLENGE"
+    certbot certonly --non-interactive --keep-until-expiring --expand \
+        --email "$EMAIL" --agree-tos \
+        --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
+        --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" --standalone
 fi
 
 # copy certs to store


### PR DESCRIPTION
### Preface
Using the Let's Encrypt addon, a new certificate cannot be requested (e.g. if you add or remove domains) if you've already generated a certificate. This is problematic if you have renamed your host, or moved to a new domain, or in the case of any of a number of other reasons that you need to generate a new certificate.

### Original configuration and initial request result
Below is a redacted copy of my configuration, likely similar to most users:
```yaml
email: sysadmin@example.com
domains:
  - hass.example.com
certfile: fullchain.pem
keyfile: privkey.pem
challenge: dns
dns:
  provider: dns-cloudflare
  cloudflare_email: admin@example.com
  cloudflare_api_key: 0123456789abcdef0123456789abcdef01234
```

Resultant log data following starting the Let's Encrypt addon:
```log
[17:31:59] INFO: Selected DNS Provider: dns-cloudflare
[17:31:59] INFO: Use propagation seconds: 60
[17:32:03] WARNING: Use CloudFlare global key (not recommended!)
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator dns-cloudflare, Installer None
Obtaining a new certificate
Performing the following challenges:
dns-01 challenge for hass.example.com
Waiting 60 seconds for DNS changes to propagate
Waiting for verification...
Cleaning up challenges
Non-standard path(s), might not work with crontab installed by your operating system package manager
IMPORTANT NOTES:
 - Congratulations! Your certificate and chain have been saved at:
   /data/letsencrypt/live/hass.example.com/fullchain.pem
   Your key file has been saved at:
   /data/letsencrypt/live/hass.example.com/privkey.pem
   Your cert will expire on 2020-05-28. To obtain a new or tweaked
   version of this certificate in the future, simply run certbot
   again. To non-interactively renew *all* of your certificates, run
   "certbot renew"
 - Your account credentials have been saved in your Certbot
   configuration directory at /data/letsencrypt. You should make a
   secure backup of this folder now. This configuration directory will
   also contain certificates and private keys obtained by Certbot so
   making regular backups of this folder is ideal.
 - If you like Certbot, please consider supporting our work by:
   Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
   Donating to EFF:                    https://eff.org/donate-le
```

### Modified configuration and subsequent request result
If we change the configuration to use a different domain, such as moving to a subdomain, using a different domain, or adding additional domains, the addon fails to request a new certificate (for reasons later discussed).
```yaml
email: sysadmin@example.com
domains:
  - hass.example.com
  - homeassistant.example.com    # Note the additional second domain here
certfile: fullchain.pem
keyfile: privkey.pem
challenge: dns
dns:
  provider: dns-cloudflare
  cloudflare_email: admin@example.com
  cloudflare_api_key: 0123456789abcdef0123456789abcdef01234
```

Resultant log data following starting the Let's Encrypt addon:
```log
[17:37:53] INFO: Selected DNS Provider: dns-cloudflare
[17:37:53] INFO: Use propagation seconds: 60
[17:37:57] WARNING: Use CloudFlare global key (not recommended!)
Saving debug log to /var/log/letsencrypt/letsencrypt.log
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Processing /data/letsencrypt/renewal/hass.example.com.conf
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Cert not yet due for renewal
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
The following certs are not due for renewal yet:
  /data/letsencrypt/live/hass.example.com/fullchain.pem expires on 2020-05-28 (skipped)
No renewals were attempted.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
```

### Investigation of the issue and proposed resolution
The issue appears to be caused by the addon's `run.sh` script's simplistic check for whether or not a certificate needs to be requested.
```sh
105| ### /mnt/data/supervisor/addons/core/letsencrypt/data/run.sh
106| # Generate new certs
107| if [ ! -d "$CERT_DIR/live" ]; then
108|     DOMAIN_ARR=()
109|     for line in $DOMAINS; do
110|         DOMAIN_ARR+=(-d "$line")
111|     done
112| 
113|     echo "$DOMAINS" > /data/domains.gen
114|     if [ "$CHALLENGE" == "dns" ]; then
115|         certbot certonly --non-interactive --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" "${PROVIDER_ARGUMENTS[@]}" --email "$EMAIL" --agree-tos --config-dir "$CE
116|     else
117|         certbot certonly --non-interactive --standalone --email "$EMAIL" --agree-tos --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" --preferred-challenges "$CHALLE
118|     fi
119| else
120|     certbot renew --non-interactive --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" --preferred-challenges "$CHALLENGE"
121| fi
122| 
123| # copy certs to store
124| cp "$CERT_DIR"/live/*/privkey.pem "/ssl/$KEYFILE"
125| cp "$CERT_DIR"/live/*/fullchain.pem "/ssl/$CERTFILE"
```

Lines 108 through 118, where the requesting of a new certificate takes place, are ignored if the `live` directory exists (generated when the first certificate is issued). I understand this is to to avoid re-requesting a certificate every time the addon is started, however through passing some flags to the certbot command the same result can be achieved while also allowing for a certificate to be expanded.

I recommend changing the code to always use `certbot certonly` instead of `certbot renew` as the latter does not provide a facility to expand certificates. Through passing command flags to `certbot certonly`, you can still ensure a new certificate is only requested when the previous certificate is close to expiration (30 days) but also request a new one if domains are changed. This PR will suffice to accomplish that through the use of the `--keep-until-expiring` flag (to ensure that we don't request a certificate too early) and the `--expand` flag (to ensure that domains being changed results in a new certificate being issued). See the code for the changes made, which also includes minor cleanups to improve readability of the commands and duplicate passing of the `--config-dir` and `--work-dir` flags (in the `if [ "$CHALLENGE" == "dns" ]; then` section).

I validated the changes this pull request implements by using a modified `run.sh` and starting the addon.

### Modified configuration (and run.sh) and subsequent request result
```yaml
email: sysadmin@example.com
domains:
  - hass.example.com
  - homeassistant.example.com    
  - home-assistant.example.com    # Note the additional third domain here
certfile: fullchain.pem
keyfile: privkey.pem
challenge: dns
dns:
  provider: dns-cloudflare
  cloudflare_email: admin@example.com
  cloudflare_api_key: 0123456789abcdef0123456789abcdef01234
```

Resultant log data following starting the Let's Encrypt addon:
Shown below, the script now properly captures the two (one from the failed attempt, and one from from the second edited config above) domains and adds them to the new certificate request.
```log
[19:12:35] INFO: Selected DNS Provider: dns-cloudflare
[19:12:35] INFO: Use propagation seconds: 60
[19:12:39] WARNING: Use CloudFlare global key (not recommended!)
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator dns-cloudflare, Installer None
Renewing an existing certificate
Performing the following challenges:
dns-01 challenge for homeassistant.example.com
dns-01 challenge for home-assistant.example.com
Waiting 60 seconds for DNS changes to propagate
Waiting for verification...
Cleaning up challenges
IMPORTANT NOTES:
 - Congratulations! Your certificate and chain have been saved at:
   /data/letsencrypt/live/hass.example.com/fullchain.pem
   Your key file has been saved at:
   /data/letsencrypt/live/hass.example.com/privkey.pem
   Your cert will expire on 2020-05-28. To obtain a new or tweaked
   version of this certificate in the future, simply run certbot
   again. To non-interactively renew *all* of your certificates, run
   "certbot renew"
 - If you like Certbot, please consider supporting our work by:
   Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
   Donating to EFF:                    https://eff.org/donate-le
```

### Same configuration and final request result
For the final test, I left the last edited configuration in place.
```yaml
email: sysadmin@example.com
domains:
  - hass.example.com
  - homeassistant.example.com    
  - home-assistant.example.com
certfile: fullchain.pem
keyfile: privkey.pem
challenge: dns
dns:
  provider: dns-cloudflare
  cloudflare_email: admin@example.com
  cloudflare_api_key: 0123456789abcdef0123456789abcdef01234
```

I started the addon again and was presented with a proper exit, without requesting a new certificate.
```log
[19:19:55] INFO: Selected DNS Provider: dns-cloudflare
[19:19:55] INFO: Use propagation seconds: 60
[19:19:59] WARNING: Use CloudFlare global key (not recommended!)
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator dns-cloudflare, Installer None
Cert not yet due for renewal
Keeping the existing certificate
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Certificate not yet due for renewal; no action taken.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
```