### PR TITLE
Update Almond to 1.7.3

### DIFF
--- a/almond/build.json
+++ b/almond/build.json
@@ -5,6 +5,6 @@
     "armv7": "homeassistant/armv7-base-debian:buster"
   },
   "args": {
-    "ALMOND_VERSION": "v1.7.2"
+    "ALMOND_VERSION": "v1.7.3"
   }
 }

--- a/almond/config.json
+++ b/almond/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Almond",
-  "version": "0.8",
+  "version": "0.9",
   "slug": "almond",
   "description": "The home server version of Almond",
   "url": "https://github.com/home-assistant/hassio-addons/blob/master/almond",


### PR DESCRIPTION
By the way, would it make sense for the addon version to be the same as the version of Almond?
It would simplify the documentation I think.