### PR TITLE
letsencrypt: Adds cron based daily renewal check and restart on success. …

### DIFF
--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -36,5 +36,9 @@ RUN apk add --no-cache --update \
 
 # Copy data
 COPY data/run.sh /
+COPY data/deploy.sh /
+COPY data/renew.sh /
+COPY data/lib /opt/letsencrypt/lib
+RUN chmod 755 /run.sh /deploy.sh /renew.sh
 
 CMD [ "/run.sh" ]

--- a/letsencrypt/config.json
+++ b/letsencrypt/config.json
@@ -7,6 +7,8 @@
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "once",
   "boot": "manual",
+  "hassio_api": true,
+  "hassio_role": "manager",
   "ports": {
     "80/tcp": 80
   },
@@ -20,7 +22,11 @@
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "challenge": "http",
-    "dns": {}
+    "dns": {},
+    "renewal_daily_check": true,
+    "renewal_check_time": "02:00",
+    "restart_core": true,
+    "restart_addons":[null]
   },
   "schema": {
     "email": "email",
@@ -28,6 +34,12 @@
     "certfile": "str",
     "keyfile": "str",
     "challenge": "list(dns|http)",
+    "renewal_daily_check": "bool",
+    "refresh_check_time": "str",
+    "restart_core": "bool",
+    "restart_addons":["str"],
+    "dev_use_staging": "bool",
+    "dev_force_renewal": "bool",
     "dns": {
       "provider": "list(dns-cloudflare|dns-cloudxns|dns-digitalocean|dns-dnsimple|dns-dnsmadeeasy|dns-gehirn|dns-google|dns-linode|dns-luadns|dns-nsone|dns-ovh|dns-rfc2136|dns-route53|dns-sakuracloud|dns-netcup)?",
       "propagation_seconds": "int(60,3600)?",

--- a/letsencrypt/data/deploy.sh
+++ b/letsencrypt/data/deploy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bashio
+
+source "/opt/letsencrypt/lib/letsencrypt.sh"
+
+DOMAINS=$(bashio::config 'domains')
+KEYFILE=$(bashio::config 'keyfile')
+CERTFILE=$(bashio::config 'certfile')
+
+CERT_DIR=$(letsencrypt::cert_dir)
+
+DOMAINS_ARRAY=(${DOMAINS[@]})
+PRIMARY_DOMAIN="${DOMAINS_ARRAY[0]}"
+
+# copy certs to store
+cp "$CERT_DIR"/live/${PRIMARY_DOMAIN}/privkey.pem "/ssl/$KEYFILE"
+cp "$CERT_DIR"/live/${PRIMARY_DOMAIN}/fullchain.pem "/ssl/$CERTFILE"
+
+# see if we need to restart the core
+if bashio::config.exists 'restart_core' && bashio::config.true 'restart_core'; then
+    bashio::log.info "Restarting Home Assistant Core"
+    bashio::core.restart
+fi
+
+if  bashio::config.exists 'restart_addons' && ! bashio::config.is_empty 'restart_addons'; then
+    RESTART_ADDONS=$(bashio::config 'restart_addons')
+    # restart the set addons
+    for addon in $RESTART_ADDONS; do
+        bashio::cache.flush_all
+        state=$(bashio::addon.state "${addon}")
+        if [[ "$state" == "started" ]]; then
+            bashio::log.info "Restarting Addon ${addon}"
+            bashio::addon.restart "${addon}"
+        else
+            echo "Not restarting ${addon} because its currently ${state}"
+        fi
+    done
+fi

--- a/letsencrypt/data/deploy.sh
+++ b/letsencrypt/data/deploy.sh
@@ -9,6 +9,7 @@ CERTFILE=$(bashio::config 'certfile')
 
 CERT_DIR=$(letsencrypt::cert_dir)
 
+# shellcheck disable=SC2206
 DOMAINS_ARRAY=(${DOMAINS[@]})
 PRIMARY_DOMAIN="${DOMAINS_ARRAY[0]}"
 

--- a/letsencrypt/data/deploy.sh
+++ b/letsencrypt/data/deploy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bashio
 
+# shellcheck disable=SC1091
 source "/opt/letsencrypt/lib/letsencrypt.sh"
 
 DOMAINS=$(bashio::config 'domains')
@@ -12,8 +13,8 @@ DOMAINS_ARRAY=(${DOMAINS[@]})
 PRIMARY_DOMAIN="${DOMAINS_ARRAY[0]}"
 
 # copy certs to store
-cp "$CERT_DIR"/live/${PRIMARY_DOMAIN}/privkey.pem "/ssl/$KEYFILE"
-cp "$CERT_DIR"/live/${PRIMARY_DOMAIN}/fullchain.pem "/ssl/$CERTFILE"
+cp "${CERT_DIR}/live/${PRIMARY_DOMAIN}/privkey.pem" "/ssl/$KEYFILE"
+cp "${CERT_DIR}/live/${PRIMARY_DOMAIN}/fullchain.pem" "/ssl/$CERTFILE"
 
 # see if we need to restart the core
 if bashio::config.exists 'restart_core' && bashio::config.true 'restart_core'; then

--- a/letsencrypt/data/lib/letsencrypt.sh
+++ b/letsencrypt/data/lib/letsencrypt.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Home Assistant Add-ons: Lets Encrypt Functions
+# These are functions to support the Lets Encrypt Addon.
+# ==============================================================================
+
+# Stores the location of this library
+readonly __LETSENCRYPT_LIB_DIR=$(dirname "${BASH_SOURCE[0]}")
+readonly __LETSENCRYPT_DEFAULT_CERT_DIR="/data/letsencrypt"
+readonly __LETSENCRYPT_DEFAULT_WORK_DIR="/data/workdir"
+
+
+
+declare __LETSENCRYPT_CERT_DIR=${LETSENCRYPT_CERT_DIR:-${__LETSENCRYPT_DEFAULT_CERT_DIR}}
+declare __LETSENCRYPT_WORK_DIR=${LETSENCRYPT_WORK_DIR:-${__LETSENCRYPT_DEFAULT_WORK_DIR}}
+
+# ------------------------------------------------------------------------------
+# Gets the renewal option setting for the renew command
+# ------------------------------------------------------------------------------
+function letsencrypt::renewal_options() {
+    if bashio::config.true 'dev_force_renewal'; then
+        bashio::log.warning "Forcing renewal on every attempt."
+        echo -n -e "--force-renewal"
+    else
+        echo -n -e ""
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Gets the server option setting all the certbot commands
+# This is to allow for a development environment using the lets encrypt staging
+# server
+# ------------------------------------------------------------------------------
+function letsencrypt::server_options() {
+    if bashio::config.true 'dev_use_staging'; then
+        bashio::log.warning "Using Lets Encrypt Staging Server. A valid certificate will not be issued"
+        echo -n -e "--server https://acme-staging-v02.api.letsencrypt.org/directory"
+    else
+        echo -n -e ""
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Gets the certificate directory to use with the certbot
+# ------------------------------------------------------------------------------
+function letsencrypt::cert_dir() {
+    echo -n -e "${__LETSENCRYPT_CERT_DIR}"
+}
+
+# ------------------------------------------------------------------------------
+# Gets the working directory to use with the certbot
+# ------------------------------------------------------------------------------
+function letsencrypt::work_dir() {
+    echo -n -e "${__LETSENCRYPT_CERT_DIR}"
+}
+
+# ------------------------------------------------------------------------------
+# Converts a 24hr time (hh:mm) to a crontab entry
+#
+# Arguments:
+#   $1 the 24hr time (hh:mm) to convert
+# ------------------------------------------------------------------------------
+function letsencrypt::crontab_convert() {
+    local renewal_check_time=${1:-'00:00'}
+    bashio::log.trace "${FUNCNAME[0]}"
+    IFS=':' read -ra RENEWAL_TIME <<< "${renewal_check_time}"
+    hour="${RENEWAL_TIME[0]}"
+    minute="${RENEWAL_TIME[1]}"
+    echo -n -e "${minute} ${hour} * * *"
+}

--- a/letsencrypt/data/lib/letsencrypt.sh
+++ b/letsencrypt/data/lib/letsencrypt.sh
@@ -5,7 +5,6 @@
 # ==============================================================================
 
 # Stores the location of this library
-readonly __LETSENCRYPT_LIB_DIR=$(dirname "${BASH_SOURCE[0]}")
 readonly __LETSENCRYPT_DEFAULT_CERT_DIR="/data/letsencrypt"
 readonly __LETSENCRYPT_DEFAULT_WORK_DIR="/data/workdir"
 
@@ -34,9 +33,9 @@ function letsencrypt::renewal_options() {
 function letsencrypt::server_options() {
     if bashio::config.true 'dev_use_staging'; then
         bashio::log.warning "Using Lets Encrypt Staging Server. A valid certificate will not be issued"
-        echo -n -e "--server https://acme-staging-v02.api.letsencrypt.org/directory"
+        echo -n -e "https://acme-staging-v02.api.letsencrypt.org/directory"
     else
-        echo -n -e ""
+        echo -n -e "https://acme-v02.api.letsencrypt.org/directory"
     fi
 }
 
@@ -51,7 +50,7 @@ function letsencrypt::cert_dir() {
 # Gets the working directory to use with the certbot
 # ------------------------------------------------------------------------------
 function letsencrypt::work_dir() {
-    echo -n -e "${__LETSENCRYPT_CERT_DIR}"
+    echo -n -e "${__LETSENCRYPT_WORK_DIR}"
 }
 
 # ------------------------------------------------------------------------------

--- a/letsencrypt/data/renew.sh
+++ b/letsencrypt/data/renew.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bashio
 
+# shellcheck disable=SC1091
 source "/opt/letsencrypt/lib/letsencrypt.sh"
 
 CHALLENGE=$(bashio::config 'challenge')
@@ -11,4 +12,4 @@ SERVER_OPTIONS=$(letsencrypt::server_options)
 
 certbot renew --non-interactive --config-dir "$CERT_DIR" \
     --work-dir "$WORK_DIR" --preferred-challenges "$CHALLENGE" \
-    --deploy-hook "/deploy.sh" $SERVER_OPTIONS $RENEWAL_OPTIONS
+    --deploy-hook "/deploy.sh" --server "${SERVER_OPTIONS}" "$RENEWAL_OPTIONS"

--- a/letsencrypt/data/renew.sh
+++ b/letsencrypt/data/renew.sh
@@ -9,4 +9,6 @@ WORK_DIR=$(letsencrypt::work_dir)
 RENEWAL_OPTIONS=$(letsencrypt::renewal_options)
 SERVER_OPTIONS=$(letsencrypt::server_options)
 
-certbot renew --non-interactive --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" --preferred-challenges "$CHALLENGE" --deploy-hook "/deploy.sh" $SERVER_OPTIONS $RENEWAL_OPTIONS
+certbot renew --non-interactive --config-dir "$CERT_DIR" \
+    --work-dir "$WORK_DIR" --preferred-challenges "$CHALLENGE" \
+    --deploy-hook "/deploy.sh" $SERVER_OPTIONS $RENEWAL_OPTIONS

--- a/letsencrypt/data/renew.sh
+++ b/letsencrypt/data/renew.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bashio
+
+source "/opt/letsencrypt/lib/letsencrypt.sh"
+
+CHALLENGE=$(bashio::config 'challenge')
+
+CERT_DIR=$(letsencrypt::cert_dir)
+WORK_DIR=$(letsencrypt::work_dir)
+RENEWAL_OPTIONS=$(letsencrypt::renewal_options)
+SERVER_OPTIONS=$(letsencrypt::server_options)
+
+certbot renew --non-interactive --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" --preferred-challenges "$CHALLENGE" --deploy-hook "/deploy.sh" $SERVER_OPTIONS $RENEWAL_OPTIONS

--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -108,20 +108,26 @@ else
 fi
 
 # Generate new certs
-if [ ! -d "$CERT_DIR/live" ]; then
-    DOMAIN_ARR=()
-    for line in $DOMAINS; do
-        DOMAIN_ARR+=(-d "$line")
-    done
+DOMAIN_ARR=()
+for line in $DOMAINS; do
+    DOMAIN_ARR+=(-d "$line")
+done
 
-    echo "$DOMAINS" > /data/domains.gen
-    if [ "$CHALLENGE" == "dns" ]; then
-        certbot certonly --non-interactive --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" "${PROVIDER_ARGUMENTS[@]}" --email "$EMAIL" --agree-tos --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" --preferred-challenges "$CHALLENGE" --deploy-hook "/deploy.sh" $SERVER_OPTIONS "${DOMAIN_ARR[@]}"
-    else
-        certbot certonly --non-interactive --standalone --email "$EMAIL" --agree-tos --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" --preferred-challenges "$CHALLENGE" --deploy-hook "/deploy.sh" $SERVER_OPTIONS "${DOMAIN_ARR[@]}"
-    fi
+echo "$DOMAINS" > /data/domains.gen
+if [ "$CHALLENGE" == "dns" ]; then
+    certbot certonly --non-interactive --keep-until-expiring --expand \
+    --email "$EMAIL" --agree-tos "${PROVIDER_ARGUMENTS[@]}" \
+    --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
+    --preferred-challenges "$CHALLENGE" --deploy-hook "/deploy.sh" \
+    $SERVER_OPTIONS "${DOMAIN_ARR[@]}"
+
 else
-    /renew.sh
+    certbot certonly --non-interactive --keep-until-expiring --expand \
+    --email "$EMAIL" --agree-tos  --config-dir "$CERT_DIR" \
+    --work-dir "$WORK_DIR" --preferred-challenges "$CHALLENGE" \
+    --deploy-hook "/deploy.sh" $SERVER_OPTIONS --standalone \
+    "${DOMAIN_ARR[@]}"
+
 fi
 
 #Setup Environment for Cronjob

--- a/letsencrypt/data/run.sh
+++ b/letsencrypt/data/run.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bashio
 
+# shellcheck disable=SC1091
 source "/opt/letsencrypt/lib/letsencrypt.sh"
 
 EMAIL=$(bashio::config 'email')
 DOMAINS=$(bashio::config 'domains')
-KEYFILE=$(bashio::config 'keyfile')
-CERTFILE=$(bashio::config 'certfile')
 CHALLENGE=$(bashio::config 'challenge')
 DNS_PROVIDER=$(bashio::config 'dns.provider')
 CERT_DIR=$(letsencrypt::cert_dir)
 WORK_DIR=$(letsencrypt::work_dir)
-RENEWAL_OPTIONS=$(letsencrypt::renewal_options)
 SERVER_OPTIONS=$(letsencrypt::server_options)
 RENEWAL_TIME=$(bashio::config 'renewal_check_time')
 RENEWAL_CRONTAB=$(letsencrypt::crontab_convert "${RENEWAL_TIME}")
@@ -119,13 +117,13 @@ if [ "$CHALLENGE" == "dns" ]; then
     --email "$EMAIL" --agree-tos "${PROVIDER_ARGUMENTS[@]}" \
     --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
     --preferred-challenges "$CHALLENGE" --deploy-hook "/deploy.sh" \
-    $SERVER_OPTIONS "${DOMAIN_ARR[@]}"
+    --server "${SERVER_OPTIONS}"  "${DOMAIN_ARR[@]}"
 
 else
     certbot certonly --non-interactive --keep-until-expiring --expand \
     --email "$EMAIL" --agree-tos  --config-dir "$CERT_DIR" \
     --work-dir "$WORK_DIR" --preferred-challenges "$CHALLENGE" \
-    --deploy-hook "/deploy.sh" $SERVER_OPTIONS --standalone \
+    --deploy-hook "/deploy.sh" --server "${SERVER_OPTIONS}"  --standalone \
     "${DOMAIN_ARR[@]}"
 
 fi


### PR DESCRIPTION
This adds some a basic crond based daily check for the certificate
renewal.  It will run the check as a defined 24h:min based time that
the user can define.  As well it allows for the restart of the core
and defined addons by slug on a successful renewal and deployment of
the cert.

Its adds some config options that allow for the renewal cron to be enabled and set the time for the check.  The time is a 24 hour time based HH:MM.  This gets converted to a cron entry to allow for the check for renewal to run.

```json
    "renewal_daily_check": true,
    "renewal_check_time": "02:00",
```

Of note, for development the renewal_check_time can be set to something like "\*:\*/5" which will create a cronjob which tries the renew every 5 minutes.  The time values are not validated at the moment but cron will reject invalid values.

As well on a successful initial creation or renewal it allows for the deployment to run which can now not only copy the certificates over but also restart the core and any defined addons.

```json
    "restart_core": true,
    "restart_addons":[
       "a0d7b954_glances",
       "a0d7b954_nodered"
     ]
```

The additional options are not required and will if missing default to the same behaviour as before with the checks and renewal happening only on a start of the addon.

In addition there are some development config options available to force the certbot to use the "staging" lets encrypt server (https://letsencrypt.org/docs/staging-environment/)  as well as force the renew to renew the cert all the time instead of waiting for expiry.

```json
    "dev_use_staging": "bool",
    "dev_force_renewal": "bool",
```