### PR TITLE
git_pull: Upgrade CLI to 4.2.0

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.11
+
+- Update Home Assistant CLI to 4.2.0
+
 ## 7.10
 
 - Update Home Assistant CLI to 4.1.0

--- a/git_pull/build.json
+++ b/git_pull/build.json
@@ -7,6 +7,6 @@
     "i386": "homeassistant/i386-base:3.11"
   },
   "args": {
-    "CLI_VERSION": "4.1.0"
+    "CLI_VERSION": "4.2.0"
   }
 }

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "7.10",
+  "version": "7.11",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/git_pull",

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -6,6 +6,7 @@
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/git_pull",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "advanced": true,
+  "init": false,
   "startup": "services",
   "boot": "manual",
   "hassio_api": true,


### PR DESCRIPTION
Changelog: <https://github.com/home-assistant/cli/releases/tag/4.2.0>