### PR TITLE
Allow user to set DuckDNS port

### DIFF
--- a/duckdns/config.json
+++ b/duckdns/config.json
@@ -7,6 +7,9 @@
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "services",
   "boot": "auto",
+  "ports": {
+    "80/tcp": 80
+  },
   "map": ["ssl:rw"],
   "options": {
     "lets_encrypt": {


### PR DESCRIPTION
I want to leave DuckDNS running all the time to renew certificates, but don't want to sacrifice port 80 on my local network.
If a user can set the port they can allow the domain validation to occur externally with a port forward from 80 -> ha:<high port>.