### PR TITLE
Remove advanced flag from SSH add-on

### DIFF
--- a/ssh/config.json
+++ b/ssh/config.json
@@ -6,7 +6,6 @@
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "init": false,
-  "advanced": true,
   "startup": "services",
   "ingress": true,
   "panel_icon": "mdi:console",


### PR DESCRIPTION
https://www.home-assistant.io/hassio/installation/
During step #7, we ask that the user install this addon.
But it is now hidden.

I think it's better to remove the flag here, instead of telling every user that they have to enable advanced mode in HA for it to show.