### PR TITLE
git_pull: delete key file first so we are not always appending

### DIFF
--- a/git_pull/CHANGELOG.md
+++ b/git_pull/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.12
+
+- Fix error of deployment_key eventually failing by overwriting the deployment_key every cycle
+
 ## 7.11
 
 - Update Home Assistant CLI to 4.2.0

--- a/git_pull/config.json
+++ b/git_pull/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Git pull",
-  "version": "7.11",
+  "version": "7.12",
   "slug": "git_pull",
   "description": "Simple git pull to update the local configuration",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/git_pull",

--- a/git_pull/data/run.sh
+++ b/git_pull/data/run.sh
@@ -30,6 +30,7 @@ function add-ssh-key {
     ) > ~/.ssh/config
 
     echo "[Info] Setup deployment_key on id_${DEPLOYMENT_KEY_PROTOCOL}"
+    rm -f "${HOME}/.ssh/id_${DEPLOYMENT_KEY_PROTOCOL}"
     while read -r line; do
         echo "$line" >> "${HOME}/.ssh/id_${DEPLOYMENT_KEY_PROTOCOL}"
     done <<< "$DEPLOYMENT_KEY"


### PR DESCRIPTION
`git_pull` is always appending existing key files, eventually making them usuable

I found that my config would eventually grow stale; it seems to be a few restarts that does it, so when I'm fiddling with the hass config and I hit `restart` on the `git_pull` addon to rush the 5-minute interval.

My impatience made the addon start a number of times, and eventually it would break.

Checking, (`docker exec -it addon_core_git_pull bash`) I found that `/data/options.json`) has a valid key, but my `/root/.ssh/id_rsa` file was 39935 lines long.

Fixing the `/root/.ssh/id_rsa` made the pull/check/restart work again.