### PR TITLE
Add issue template for all add-ons

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_ada.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_ada.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with Hey Ada! addon
+about: Report an issue about the Hey Ada! addon
+title: ''
+labels: 'bug, add-on: ada'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_almond.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_almond.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with Almond addon
+about: Report an issue about the Almond addon
+title: ''
+labels: 'bug, add-on: almond'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_cec_scan.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_cec_scan.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with CEC Scanner addon
+about: Report an issue about the CEC Scanner addon
+title: ''
+labels: 'bug, add-on: cec_scan'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_check_config.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_check_config.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with Check Home Assistant configuration addon
+about: Report an issue about the Check Home Assistant configuration addon
+title: ''
+labels: 'bug, add-on: check_config'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_configurator.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_configurator.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with File editor addon
+about: Report an issue about the File editor addon
+title: ''
+labels: 'bug, add-on: configurator'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_deconz.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_deconz.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with deCONZ addon
+about: Report an issue about the deCONZ addon
+title: ''
+labels: 'bug, add-on: deconz'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_dhcp_server.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_dhcp_server.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with DHCP server addon
+about: Report an issue about the DHCP server addon
+title: ''
+labels: 'bug, add-on: dhcp_server'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_dnsmasq.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_dnsmasq.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with Dnsmasq addon
+about: Report an issue about the Dnsmasq addon
+title: ''
+labels: 'bug, add-on: dnsmasq'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_duckdns.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_duckdns.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with Duck DNS addon
+about: Report an issue about the Duck DNS addon
+title: ''
+labels: 'bug, add-on: duckdns'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_git_pull.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_git_pull.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with Git pull addon
+about: Report an issue about the Git pull addon
+title: ''
+labels: 'bug, add-on: git_pull'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_google_assistant.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_google_assistant.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with Google Assistant SDK addon
+about: Report an issue about the Google Assistant SDK addon
+title: ''
+labels: 'bug, add-on: google_assistant'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_homematic.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_homematic.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with HomeMatic addon
+about: Report an issue about the HomeMatic addon
+title: ''
+labels: 'bug, add-on: homematic'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_letsencrypt.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_letsencrypt.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with Let's Encrypt addon
+about: Report an issue about the Let's Encrypt addon
+title: ''
+labels: 'bug, add-on: letsencrypt'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_mariadb.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_mariadb.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with MariaDB addon
+about: Report an issue about the MariaDB addon
+title: ''
+labels: 'bug, add-on: mariadb'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_mosquitto.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_mosquitto.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with Mosquitto broker addon
+about: Report an issue about the Mosquitto broker addon
+title: ''
+labels: 'bug, add-on: mosquitto'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_nginx_proxy.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_nginx_proxy.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with NGINX Home Assistant SSL proxy addon
+about: Report an issue about the NGINX Home Assistant SSL proxy addon
+title: ''
+labels: 'bug, add-on: nginx_proxy'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_rpc_shutdown.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_rpc_shutdown.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with RPC Shutdown addon
+about: Report an issue about the RPC Shutdown addon
+title: ''
+labels: 'bug, add-on: rpc_shutdown'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_samba.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_samba.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with Samba share addon
+about: Report an issue about the Samba share addon
+title: ''
+labels: 'bug, add-on: samba'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_snips.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_snips.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with Snips addon
+about: Report an issue about the Snips addon
+title: ''
+labels: 'bug, add-on: snips'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_ssh.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_ssh.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with SSH server addon
+about: Report an issue about the SSH server addon
+title: ''
+labels: 'bug, add-on: ssh'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report_tellstick.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_tellstick.md
@@ -1,0 +1,23 @@
+---
+name: Report a bug with TellStick addon
+about: Report an issue about the TellStick addon
+title: ''
+labels: 'bug, add-on: tellstick'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Feature Request
+    url: https://community.home-assistant.io/c/feature-requests
+    about: Please use our Community Forum for making feature requests.
+  - name: Check the Home Assistant Discord chat server
+    url: https://discord.gg/c5DvZ4e
+    about: The Home Assistant Discord chat server
+  - name: Join the reddit subreddit in /r/homeassistant
+    url: https://reddit.com/r/homeassistant
+    about: The Home Assistant subreddit
+  - name: I'm unsure where to go
+    url: https://www.home-assistant.io/join-chat
+    about: If you are unsure where to go, then joining our chat is recommended; Just ask!

--- a/.github/ISSUE_TEMPLATE/generate_templates.py
+++ b/.github/ISSUE_TEMPLATE/generate_templates.py
@@ -1,0 +1,61 @@
+# Generate templates for issues
+import os
+
+__location__ = os.path.realpath(os.path.join(
+    os.getcwd(), os.path.dirname(__file__)))
+
+# List of all the addons on this repository
+ADDONS = [
+    ("ada", "Hey Ada!"),
+    ("almond", "Almond"),
+    ("cec_scan", "CEC Scanner"),
+    ("check_config", "Check Home Assistant configuration"),
+    ("configurator", "File editor"),
+    ("deconz", "deCONZ"),
+    ("dhcp_server", "DHCP server"),
+    ("dnsmasq", "Dnsmasq"),
+    ("duckdns", "Duck DNS"),
+    ("git_pull", "Git pull"),
+    ("google_assistant", "Google Assistant SDK"),
+    ("homematic", "HomeMatic"),
+    ("letsencrypt", "Let's Encrypt"),
+    ("mariadb", "MariaDB"),
+    ("mosquitto", "Mosquitto broker"),
+    ("nginx_proxy", "NGINX Home Assistant SSL proxy"),
+    ("rpc_shutdown", "RPC Shutdown"),
+    ("samba", "Samba share"),
+    ("snips", "Snips"),
+    ("ssh", "SSH server"),
+    ("tellstick", "TellStick"),
+]
+
+BUG_TEMPLATE = """---
+name: Report a bug with {addon_title} addon
+about: Report an issue about the {addon_title} addon
+title: ''
+labels: 'bug, add-on: {addon}'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots or error stack trace**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->
+"""
+
+for addon in ADDONS:
+    filename = 'bug_report_{title}.md'.format(title=addon[0])
+    f = open(os.path.join(__location__, filename), "w")
+    f.write(BUG_TEMPLATE.format(addon_title=addon[1], addon=addon[0]))
+    f.close()


### PR DESCRIPTION
Hi,

I see a lot of issues in this repo that don't have the proper labels assigned to them.
@frenck, from what I see, you currently have to manually add the proper label for each issue created.

The goal of this PR is to standardize issues creation by letting the user/dev choose the issue template assigned to the proper add-on, in order to automatically label the issue and give that person a template about how to format his issue.

<details><summary><b>Screenshots</b></summary>
<p>
This is what the new issue page would looks like:

![github com_ericmatte_HomeAutomation_issues_new_choose](https://user-images.githubusercontent.com/9013072/80891757-375b4c00-8c94-11ea-8912-2804d1b97a67.png)

---

And this is an issue with the template:

![image](https://user-images.githubusercontent.com/9013072/80891847-b6508480-8c94-11ea-865b-4c010a8ec1a1.png)

---

As you can see in the screenshots, the labels would be added automatically:

<img src="https://user-images.githubusercontent.com/9013072/80891870-da13ca80-8c94-11ea-8f3d-176e13c19128.png" alt="Example 1" width="220">
</p>
</details>

---

To generate those templates, I have used a little script that I've added to this PR.
This script can easily be re-run like so:
```bash
python .github/ISSUE_TEMPLATE/generate_templates.py
```

I've also added a `config.yml` similar to the one in [Home Assistant Core one](https://github.com/home-assistant/core/blob/dev/.github/ISSUE_TEMPLATE/config.yml) and the bottom of [this README.md](https://github.com/home-assistant/hassio-addons/blob/master/google_assistant/README.md#support).

Let me know what you think, I can also make some adjustments to better suits the needs of this repo.

Regards,
Eric
