### PR TITLE
letsencrypt: Add Gandi DNS provider

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.8.0
+
+- Add support for Gandi DNS
+
 ## 4.7.1
 
 - Adjust init settings

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -78,6 +78,8 @@ sakuracloud_api_secret: ''
 netcup_customer_id: ''
 netcup_api_key: ''
 netcup_api_password: ''
+gandi_api_key: ''
+gandi_sharing_id: ''
 ```
 
 ## Example Configurations
@@ -224,6 +226,7 @@ dns-rfc2136
 dns-route53
 dns-sakuracloud
 dns-netcup
+dns-gandi
 ```
 
 ## Support

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -4,6 +4,7 @@ FROM $BUILD_FROM
 # setup base
 ARG CERTBOT_VERSION
 ARG CERTBOT_NETCUP_VERSION
+ARG CERTBOT_GANDI_VERSION
 
 RUN apk add --no-cache --update \
         libffi \
@@ -32,6 +33,7 @@ RUN apk add --no-cache --update \
         certbot-dns-route53==${CERTBOT_VERSION} \
         certbot-dns-sakuracloud==${CERTBOT_VERSION} \
         certbot-dns-netcup==${CERTBOT_NETCUP_VERSION} \
+        certbot-plugin-gandi==${CERTBOT_GANDI_VERSION} \
     && apk del .build-dependencies
 
 # Copy data

--- a/letsencrypt/build.json
+++ b/letsencrypt/build.json
@@ -8,6 +8,7 @@
   },
   "args": {
     "CERTBOT_VERSION": "1.2.0",
-    "CERTBOT_NETCUP_VERSION": "0.31.0.1"
+    "CERTBOT_NETCUP_VERSION": "0.31.0.1",
+    "CERTBOT_GANDI_VERSION": "1.2.5"
   }
 }

--- a/letsencrypt/config.json
+++ b/letsencrypt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Let's Encrypt",
-  "version": "4.7.1",
+  "version": "4.8.0",
   "slug": "letsencrypt",
   "description": "Manage certificate from Let's Encrypt",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/letsencrypt",
@@ -30,7 +30,7 @@
     "keyfile": "str",
     "challenge": "list(dns|http)",
     "dns": {
-      "provider": "list(dns-cloudflare|dns-cloudxns|dns-digitalocean|dns-dnsimple|dns-dnsmadeeasy|dns-gehirn|dns-google|dns-linode|dns-luadns|dns-nsone|dns-ovh|dns-rfc2136|dns-route53|dns-sakuracloud|dns-netcup)?",
+      "provider": "list(dns-cloudflare|dns-cloudxns|dns-digitalocean|dns-dnsimple|dns-dnsmadeeasy|dns-gehirn|dns-google|dns-linode|dns-luadns|dns-nsone|dns-ovh|dns-rfc2136|dns-route53|dns-sakuracloud|dns-netcup|dns-gandi)?",
       "propagation_seconds": "int(60,3600)?",
       "cloudflare_email": "email?",
       "cloudflare_api_key": "str?",
@@ -64,7 +64,9 @@
       "sakuracloud_api_secret": "str?",
       "netcup_customer_id": "str?",
       "netcup_api_key": "str?",
-      "netcup_api_password": "str?"
+      "netcup_api_password": "str?",
+      "gandi_api_key": "str?",
+      "gandi_sharing_id": "str?"
     }
   },
   "image": "homeassistant/{arch}-addon-letsencrypt"

--- a/letsencrypt/rootfs/etc/cont-init.d/file-structure.sh
+++ b/letsencrypt/rootfs/etc/cont-init.d/file-structure.sh
@@ -34,6 +34,7 @@ echo -e "dns_cloudxns_api_key = $(bashio::config 'dns.cloudxns_api_key')\n" \
       "aws_access_key_id = $(bashio::config 'dns.aws_access_key_id')\n" \
       "aws_secret_access_key = $(bashio::config 'dns.aws_secret_access_key')\n" \
       "dns_sakuracloud_api_token = $(bashio::config 'dns.sakuracloud_api_token')\n" \
-      "dns_sakuracloud_api_secret = $(bashio::config 'dns.sakuracloud_api_secret')" > /data/dnsapikey
+      "dns_sakuracloud_api_secret = $(bashio::config 'dns.sakuracloud_api_secret')\n" \
+      "certbot_plugin_gandi:dns_api_key = $(bashio::config 'dns.gandi_api_key')" > /data/dnsapikey
 
 chmod 600 /data/dnsapikey

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -63,6 +63,14 @@ elif [ "${DNS_PROVIDER}" == "dns-cloudflare" ]; then
 
     PROVIDER_ARGUMENTS+=("--${DNS_PROVIDER}" "--${DNS_PROVIDER}-credentials" /data/dnsapikey "--dns-cloudflare-propagation-seconds" "${PROPAGATION_SECONDS}")
 
+# Gandi
+elif [ "${DNS_PROVIDER}" == "dns-gandi" ]; then
+    if bashio::config.exists 'dns.gandi_sharing_id'; then
+        bashio::log.info "Use Gandi sharing ID"
+        echo "certbot_plugin_gandi:dns_sharing_id = $(bashio::config 'dns.gandi_sharing_id')" >> /data/dnsapikey
+    fi
+    PROVIDER_ARGUMENTS+=("--authenticator" "certbot-plugin-gandi:dns" "--certbot-plugin-gandi:dns-credentials" /data/dnsapikey)
+
 #All others
 else
     PROVIDER_ARGUMENTS+=("--${DNS_PROVIDER}" "--${DNS_PROVIDER}-credentials" /data/dnsapikey)


### PR DESCRIPTION
This is using https://pypi.org/project/certbot-plugin-gandi/ and is
loosely based on commit ae84a86209 which added support for netcup.