### PR TITLE
ssh: Mention port setting in step by step instructions

### DIFF
--- a/ssh/README.md
+++ b/ssh/README.md
@@ -26,9 +26,6 @@ Follow these steps to get the add-on installed on your system:
 
 ## How to use
 
-You need enable the port for external access. You can just enter 22 as value or any other
-value like you want. This recommend to add login credentials.
-
 To use this add-on, you must have a private/public key to log in.
 To generate them, follow the [instructions for Windows][keygen-windows]
 and [these for other platforms][keygen]. It is possible to set a password for
@@ -38,8 +35,10 @@ You can not run both variants at the same time. Enabling login via keys, will
 disable password login.
 
 1. Add a ssh key to  `authorized_keys` or set a `password` in the add-on configuration.
-2. Start the add-on.
-3. Connect to your device using your preferred SSH client and use `root` as
+2. Add a host port in the 'Network' section of the add-on configuration. You can use 22
+   or any other value that you wish.
+3. Start the add-on.
+4. Connect to your device using your preferred SSH client and use `root` as
    the username.
 
 After logging in, you will find yourself in this add-on’s container.


### PR DESCRIPTION
When trying to use the ssh add-on, I was very confused by that "null"
value in the plugin configuration, and why I could not access my
home-assistant instance by ssh, ... It was not clear to me that the
initial mention of port 22 was about configuration in the add-on
configuration or some configuration to do on your home network.

Moving the port description to the step by step instructions for
configuring the add-on should clear that up.