### PR TITLE
almond: Split documentation

### DIFF
--- a/almond/DOCS.md
+++ b/almond/DOCS.md
@@ -1,0 +1,40 @@
+# Home Assistant Add-on: Almond
+
+## Installation
+
+Follow these steps to get the add-on installed on your system:
+
+1. Navigate in your Home Assistant frontend to **Supervisor** -> **Add-on Store**.
+2. Find the "Almond" add-on and click it.
+3. Click on the "INSTALL" button.
+
+## How to use
+
+The basic thing to get the add-on running would be:
+
+1. Start the add-on.
+2. Go the the Home Assistant frontend -> **Configuration** -> **Integrations**
+   to configure Home Assistant to use this add-on. After starting,
+   it will be automatically discovered by Home Assistant.
+
+## Configuration
+
+This add-on has no additional configuration options.
+
+## Support
+
+Got questions?
+
+You have several options to get them answered:
+
+- The [Home Assistant Discord Chat Server][discord].
+- The Home Assistant [Community Forum][forum].
+- Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
+
+In case you've found a bug, please [open an issue on our GitHub][issue].
+
+[discord]: https://discord.gg/c5DvZ4e
+[forum]: https://community.home-assistant.io
+[issue]: https://github.com/home-assistant/hassio-addons/issues
+[reddit]: https://reddit.com/r/homeassistant
+[repository]: https://github.com/hassio-addons/repository

--- a/almond/README.md
+++ b/almond/README.md
@@ -4,49 +4,11 @@
 
 ![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
 
-## About
-
-## Installation
-
-Follow these steps to get the add-on installed on your system:
-
-1. Navigate in your Home Assistant frontend to **Supervisor** -> **Add-on Store**.
-2. Find the "Almond" add-on and click it.
-3. Click on the "INSTALL" button.
-
-## How to use
-
-The basic thing to get the add-on running would be:
-
-1. Start the add-on.
-2. Go the the Home Assistant frontend -> **Configuration** -> **Integrations**
-   to configure Home Assistant to use this add-on. After starting,
-   it will be automatically discovered by Home Assistant.
-
-## Configuration
-
-This add-on has no additional configuration options.
-
-## Support
-
-Got questions?
-
-You have several options to get them answered:
-
-- The [Home Assistant Discord Chat Server][discord].
-- The Home Assistant [Community Forum][forum].
-- Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
-
-In case you've found a bug, please [open an issue on our GitHub][issue].
+The Open, Privacy-Preserving Virtual Assistant.
 
 [Almond]: https://almond.stanford.edu/
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[discord]: https://discord.gg/c5DvZ4e
-[forum]: https://community.home-assistant.io
 [i386-shield]: https://img.shields.io/badge/i386-no-red.svg
-[issue]: https://github.com/home-assistant/hassio-addons/issues
-[reddit]: https://reddit.com/r/homeassistant
-[repository]: https://github.com/hassio-addons/repository


### PR DESCRIPTION
Splits the documentation from the README for the Almond add-on.
Result: Documentation now available in the Supervisor frontend.