### PR TITLE
cec_scan: Split documentation

### DIFF
--- a/cec_scan/DOCS.md
+++ b/cec_scan/DOCS.md
@@ -1,0 +1,34 @@
+# Home Assistant Add-on: CEC Scanner
+
+## Installation
+
+Follow these steps to get the add-on installed on your system:
+
+1. Navigate in your Home Assistant frontend to **Supervisor** -> **Add-on Store**.
+2. Find the "CEC Scanner" add-on and click it.
+3. Click on the "INSTALL" button.
+
+## How to use
+
+This add-on has no configuration and runs out of the box.
+
+1. Start the add-on.
+2. Check the add-on log output to see the result.
+
+## Support
+
+Got questions?
+
+You have several options to get them answered:
+
+- The [Home Assistant Discord Chat Server][discord].
+- The Home Assistant [Community Forum][forum].
+- Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
+
+In case you've found a bug, please [open an issue on our GitHub][issue].
+
+[discord]: https://discord.gg/c5DvZ4e
+[forum]: https://community.home-assistant.io
+[issue]: https://github.com/home-assistant/hassio-addons/issues
+[reddit]: https://reddit.com/r/homeassistant
+[repository]: https://github.com/hassio-addons/repository

--- a/cec_scan/README.md
+++ b/cec_scan/README.md
@@ -4,45 +4,11 @@ Scan & discover HDMI CEC devices and their addresses.
 
 ![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
 
-## About
-
 This add-on allows for scanning for CEC devices. It is useful for finding
 the CEC address of your devices.
-
-## Installation
-
-Follow these steps to get the add-on installed on your system:
-
-1. Navigate in your Home Assistant frontend to **Supervisor** -> **Add-on Store**.
-2. Find the "CEC Scanner" add-on and click it.
-3. Click on the "INSTALL" button.
-
-## How to use
-
-This add-on has no configuration and runs out of the box.
-
-1. Start the add-on.
-2. Check the add-on log output to see the result.
-
-## Support
-
-Got questions?
-
-You have several options to get them answered:
-
-- The [Home Assistant Discord Chat Server][discord].
-- The Home Assistant [Community Forum][forum].
-- Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
-
-In case you've found a bug, please [open an issue on our GitHub][issue].
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[discord]: https://discord.gg/c5DvZ4e
-[forum]: https://community.home-assistant.io
 [i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
-[issue]: https://github.com/home-assistant/hassio-addons/issues
-[reddit]: https://reddit.com/r/homeassistant
-[repository]: https://github.com/hassio-addons/repository


### PR DESCRIPTION
Splits the documentation from the README for the HDMI-CEC add-on.
Result: Documentation now available in the Supervisor frontend.