### PR TITLE
configurator: Split documentation

### DIFF
--- a/configurator/DOCS.md
+++ b/configurator/DOCS.md
@@ -1,0 +1,71 @@
+# Home Assistant Add-on: File editor
+
+## Installation
+
+Follow these steps to get the add-on installed on your system:
+
+1. Navigate in your Home Assistant frontend to **Supervisor** -> **Add-on Store**.
+2. Find the "File editor" add-on and click it.
+3. Click on the "INSTALL" button.
+
+## How to use
+
+In general, this add-on requires no configuration from your end.
+
+1. Toggle the "Show in sidebar" option, which adds the File editor to the main menu.
+2. Start the add-on.
+3. Refresh your browser, the "File editor" is now visible in the sidebar.
+4. Click on the "File editor" menu option and start configuring!
+
+## Configuration
+
+Add-on configuration:
+
+```yaml
+dirsfirst: false
+enforce_basepath: false
+ignore_pattern:
+  - __pycache__
+ssh_keys: []
+```
+
+### Option: `dirsfirst` (required)
+
+This option allows you to list directories before files in the file browser tree.
+
+Set it to `true` to list directories first, `false` otherwise.
+
+### Option: `enforce_basepath` (required)
+
+If set to `true`, access is limited to files within the `/config` directory.
+
+### Option: `ignore_pattern` (required)
+
+This option allows you to hide files and folders from the file browser tree.
+By default, it hides the `__pycache__` folders.
+
+### Option: `ssh_keys` (required)
+
+A list of filenames containing SSH private keys. These can be used to allow for access to remote git repositories.
+
+## Known issues and limitations
+
+- This add-on can only be used via Ingress and has no direct access.
+
+## Support
+
+Got questions?
+
+You have several options to get them answered:
+
+- The [Home Assistant Discord Chat Server][discord].
+- The Home Assistant [Community Forum][forum].
+- Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
+
+In case you've found a bug, please [open an issue on our GitHub][issue].
+
+[discord]: https://discord.gg/c5DvZ4e
+[forum]: https://community.home-assistant.io
+[issue]: https://github.com/home-assistant/hassio-addons/issues
+[reddit]: https://reddit.com/r/homeassistant
+[repository]: https://github.com/hassio-addons/repository

--- a/configurator/README.md
+++ b/configurator/README.md
@@ -30,78 +30,9 @@ configuration files) will be automatically checked for syntax errors while editi
 - Editor settings are saved in your browser.
 - And much more…
 
-## Installation
-
-Follow these steps to get the add-on installed on your system:
-
-1. Navigate in your Home Assistant frontend to **Supervisor** -> **Add-on Store**.
-2. Find the "File editor" add-on and click it.
-3. Click on the "INSTALL" button.
-
-## How to use
-
-In general, this add-on requires no configuration from your end.
-
-1. Toggle the "Show in sidebar" option, which adds the File editor to the main menu.
-2. Start the add-on.
-3. Refresh your browser, the "File editor" is now visible in the sidebar.
-4. Click on the "File editor" menu option and start configuring!
-
-## Configuration
-
-Add-on configuration:
-
-```yaml
-dirsfirst: false
-enforce_basepath: false
-ignore_pattern:
-  - __pycache__
-ssh_keys: []
-```
-
-### Option: `dirsfirst` (required)
-
-This option allows you to list directories before files in the file browser tree.
-
-Set it to `true` to list directories first, `false` otherwise.
-
-### Option: `enforce_basepath` (required)
-
-If set to `true`, access is limited to files within the `/config` directory.
-
-### Option: `ignore_pattern` (required)
-
-This option allows you to hide files and folders from the file browser tree.
-By default, it hides the `__pycache__` folders.
-
-### Option: `ssh_keys` (required)
-
-A list of filenames containing SSH private keys. These can be used to allow for access to remote git repositories.
-
-## Known issues and limitations
-
-- This add-on can only be used via Ingress and has no direct access.
-
-## Support
-
-Got questions?
-
-You have several options to get them answered:
-
-- The [Home Assistant Discord Chat Server][discord].
-- The Home Assistant [Community Forum][forum].
-- Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
-
-In case you've found a bug, please [open an issue on our GitHub][issue].
-
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[discord]: https://discord.gg/c5DvZ4e
-[forum]: https://community.home-assistant.io
 [i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
-[issue]: https://github.com/home-assistant/hassio-addons/issues
-[reddit]: https://reddit.com/r/homeassistant
-[repository]: https://github.com/hassio-addons/repository
 [screenshot]: https://github.com/home-assistant/hassio-addons/raw/master/configurator/images/screenshot.png


### PR DESCRIPTION
Splits the documentation from the README for the File Editor add-on.
Result: Documentation now available in the Supervisor frontend.