### PR TITLE
deconz: Bump deCONZ to 2.05.77

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.3.4
+
+- Bump deCONZ to 2.05.77
+
 ## 5.3.3
 
 - Bump deCONZ to 2.05.76

--- a/deconz/build.json
+++ b/deconz/build.json
@@ -5,6 +5,6 @@
     "armhf": "homeassistant/armhf-base-raspbian:stretch"
   },
   "args": {
-    "DECONZ_VERSION": "2.05.76"
+    "DECONZ_VERSION": "2.05.77"
   }
 }

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "slug": "deconz",
   "description": "Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],


### PR DESCRIPTION
Bump deCONZ to 2.05.77

Release notes: https://github.com/dresden-elektronik/deconz-rest-plugin/tree/V2_05_77