### PR TITLE
nginx_proxy: Fix the use of subfolders in certificate files

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.1
+
+- Fix the use of subfolders with certificate files
+
 ## 3.0
 
 - Update Alpine to 3.11

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "NGINX Home Assistant SSL proxy",
-  "version": "3.0",
+  "version": "3.0.1",
   "slug": "nginx_proxy",
   "description": "An SSL/TLS proxy",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/nginx_proxy",

--- a/nginx_proxy/data/run.sh
+++ b/nginx_proxy/data/run.sh
@@ -49,8 +49,8 @@ if bashio::config.true 'cloudflare'; then
 fi
 
 # Prepare config file
-sed -i "s/%%FULLCHAIN%%/$CERTFILE/g" /etc/nginx.conf
-sed -i "s/%%PRIVKEY%%/$KEYFILE/g" /etc/nginx.conf
+sed -i "s#%%FULLCHAIN%%#$CERTFILE#g" /etc/nginx.conf
+sed -i "s#%%PRIVKEY%%#$KEYFILE#g" /etc/nginx.conf
 sed -i "s/%%DOMAIN%%/$DOMAIN/g" /etc/nginx.conf
 
 [ -n "$HSTS" ] && HSTS="add_header Strict-Transport-Security \"$HSTS\" always;"


### PR DESCRIPTION
The use of slashes in cert files, causes the sed replacement to break.