### PR TITLE
SSH: Add local TCP forwarding option

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.6.0
+
+- Add support for local TCP forwarding
+
 ## 8.5.4
 
 - Update Home Assistant CLI to 4.3.0

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -55,7 +55,11 @@ keys by adding multiple public keys to the list.
 
 Set a password for login. **We do NOT recommend this variant**.
 
-### Option: `allow_tcp_forwarding`
+### Option group  `server`
+
+Some SSH server options.
+
+#### Option `tcp_forwarding`
 
 Specifies whether TCP forwarding is permitted or not.
 

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -55,6 +55,12 @@ keys by adding multiple public keys to the list.
 
 Set a password for login. **We do NOT recommend this variant**.
 
+### Option: `allow_tcp_forwarding`
+
+Specifies whether TCP forwarding is permitted or not.
+
+**Note**: _Enabling this option lowers the security of your SSH server! Nevertheless, this warning is debatable._
+
 ## Network
 To enable ssh access via the network, you need to enter the port number ‘22’ or the port you want to use. This will map that port from the hassio host into the running “Terminal & SSH” container.
 

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -23,12 +23,16 @@
   "options": {
     "authorized_keys": [],
     "password": "",
-    "allow_tcp_forwarding": false
+    "server": {
+      "tcp_forwarding": false
+    }
   },
   "schema": {
     "authorized_keys": ["str"],
     "password": "str",
-    "allow_tcp_forwarding": "bool"
+    "server": {
+      "tcp_forwarding": "bool"
+    }
   },
   "image": "homeassistant/{arch}-addon-ssh"
 }

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -22,11 +22,13 @@
   "map": ["config:rw", "ssl:rw", "addons:rw", "share:rw", "backup:rw"],
   "options": {
     "authorized_keys": [],
-    "password": ""
+    "password": "",
+    "allow_tcp_forwarding": false
   },
   "schema": {
     "authorized_keys": ["str"],
-    "password": "str"
+    "password": "str",
+    "allow_tcp_forwarding": "bool"
   },
   "image": "homeassistant/{arch}-addon-ssh"
 }

--- a/ssh/config.json
+++ b/ssh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Terminal & SSH",
-  "version": "8.5.4",
+  "version": "8.6.0",
   "slug": "ssh",
   "description": "Allow logging in remotely to Home Assistant using SSH",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",

--- a/ssh/rootfs/etc/cont-init.d/ssh.sh
+++ b/ssh/rootfs/etc/cont-init.d/ssh.sh
@@ -31,6 +31,6 @@ elif bashio::var.has_value "$(bashio::addon.port 22)"; then
 fi
 
 # Allow TCP forwarding
-if bashio::config.true 'allow_tcp_forwarding'; then
+if bashio::config.true 'server.tcp_forwarding'; then
     sed -i s/AllowTcpForwarding.*/AllowTcpForwarding\ yes/ /etc/ssh/sshd_config
 fi

--- a/ssh/rootfs/etc/cont-init.d/ssh.sh
+++ b/ssh/rootfs/etc/cont-init.d/ssh.sh
@@ -29,3 +29,8 @@ elif bashio::config.has_value 'password'; then
 elif bashio::var.has_value "$(bashio::addon.port 22)"; then
     bashio::exit.nok "You need to setup a login!"
 fi
+
+# Allow TCP forwarding
+if bashio::config.true 'allow_tcp_forwarding'; then
+    sed -i s/AllowTcpForwarding.*/AllowTcpForwarding\ yes/ /etc/ssh/sshd_config
+fi

--- a/ssh/rootfs/etc/cont-init.d/ssh.sh
+++ b/ssh/rootfs/etc/cont-init.d/ssh.sh
@@ -32,5 +32,5 @@ fi
 
 # Allow TCP forwarding
 if bashio::config.true 'server.tcp_forwarding'; then
-    sed -i s/AllowTcpForwarding.*/AllowTcpForwarding\ yes/ /etc/ssh/sshd_config
+    sed -i "s/AllowTcpForwarding.*/AllowTcpForwarding\\ yes/" /etc/ssh/sshd_config
 fi


### PR DESCRIPTION
Add allow_tcp_forwarding option, to allow local port forwarding by the SSH add-on. Code lifted from the more advanced [SSH & Web Terminal](https://github.com/hassio-addons/addon-ssh) add-on.

Motivating use case: I wanted to use the ptvsd integration to help debug an issue on a remote Home Assistant instance I'm supporting. For this I would like to use port forwarding via the SSH add-on. It would also be useful for accessing the host SSH server without having to modify the router configuration to forward port 22222.