### PR TITLE
Downgraded deCONZ to 2.05.75

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.3.5
+
+- Downgrade deCONZ to 2.05.75, since it has been reported that 2.05.77, and possibly also 2.05.76, is causing issues for several users.
+
 ## 5.3.4
 
 - Bump deCONZ to 2.05.77

--- a/deconz/build.json
+++ b/deconz/build.json
@@ -5,6 +5,6 @@
     "armhf": "homeassistant/armhf-base-raspbian:stretch"
   },
   "args": {
-    "DECONZ_VERSION": "2.05.77"
+    "DECONZ_VERSION": "2.05.75"
   }
 }

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "slug": "deconz",
   "description": "Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],


### PR DESCRIPTION
Several users have experienced issues with deCONZ versions later than 2.05.75, as expressed here:

* https://github.com/dresden-elektronik/deconz-rest-plugin/issues/2863
* https://github.com/dresden-elektronik/deconz-rest-plugin/issues/2866

I'm aware that it's currently not possible to downgrade an add-on and that one is suggested to use snapshots to resolve a situation like this.

In this case though, I think it would be more appropriate to downgrade the version used by the add-on while waiting for a new deCONZ release that hopefully resolves these issues. For example to avoid issues for new users installing the add-on (without any previous installation).