### PR TITLE
letsencrypt: Add custom ACME server option

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.10.0
+
+- Add support for custom ACME server and Certificate Authority
+
 ## 4.9.0
 
 - Add support for DirectAdmin DNS

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -87,6 +87,24 @@ transip_username: ''
 transip_api_key: ''
 ```
 
+## Advanced
+
+### Changing the ACME Server
+By default, The addon uses Let’s Encrypt’s default server at https://acme-v02.api.letsencrypt.org/. You can instruct the addon to use a different ACME server by providing the field `acme_server` with the URL of the server’s ACME directory:
+
+```yaml
+acme_server: 'https://my.custom-acme-server.com'
+```
+
+If your custom ACME server uses a certificate signed by an untrusted certificate authority (CA), you can add the root certificate to the trust store by setting its content as an option:
+```yaml
+acme_server: 'https://my.custom-acme-server.com'
+acme_root_ca_cert: |
+  -----BEGIN CERTIFICATE-----
+  MccBfTCCASugAwIBAgIRAPPIPTKNBXkBozsoE46UPZcwCGYIKoZIzj0EAwIwHTEb...kg==
+  -----END CERTIFICATE-----
+```
+
 ## Example Configurations
 
 ### http challenge

--- a/letsencrypt/config.json
+++ b/letsencrypt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Let's Encrypt",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "slug": "letsencrypt",
   "description": "Manage certificate from Let's Encrypt",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/letsencrypt",
@@ -29,6 +29,8 @@
     "certfile": "str",
     "keyfile": "str",
     "challenge": "list(dns|http)",
+    "acme_server": "url?",
+    "acme_root_ca_cert": "str?",
     "dns": {
       "provider": "list(dns-cloudflare|dns-cloudxns|dns-digitalocean|dns-directadmin|dns-dnsimple|dns-dnsmadeeasy|dns-gehirn|dns-google|dns-linode|dns-luadns|dns-nsone|dns-ovh|dns-rfc2136|dns-route53|dns-sakuracloud|dns-netcup|dns-gandi|dns-transip)?",
       "propagation_seconds": "int(60,3600)?",

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -5,6 +5,7 @@
 CERT_DIR=/data/letsencrypt
 WORK_DIR=/data/workdir
 PROVIDER_ARGUMENTS=()
+ACME_CUSTOM_SERVER_ARGUMENTS=()
 
 EMAIL=$(bashio::config 'email')
 DOMAINS=$(bashio::config 'domains')
@@ -12,6 +13,8 @@ KEYFILE=$(bashio::config 'keyfile')
 CERTFILE=$(bashio::config 'certfile')
 CHALLENGE=$(bashio::config 'challenge')
 DNS_PROVIDER=$(bashio::config 'dns.provider')
+ACME_SERVER=$(bashio::config 'acme_server')
+ACME_ROOT_CA=$(bashio::config 'acme_root_ca_cert')
 
 if [ "${CHALLENGE}" == "dns" ]; then
     bashio::log.info "Selected DNS Provider: ${DNS_PROVIDER}"
@@ -93,6 +96,16 @@ else
     PROVIDER_ARGUMENTS+=("--${DNS_PROVIDER}" "--${DNS_PROVIDER}-credentials" /data/dnsapikey)
 fi
 
+if bashio::config.has_value 'acme_server' ; then
+    ACME_CUSTOM_SERVER_ARGUMENTS+=("--server" "${ACME_SERVER}")
+
+    if bashio::config.has_value 'acme_root_ca_cert'; then
+      echo "${ACME_ROOT_CA}" > /tmp/root-ca-cert.crt
+      # Certbot will automatically open the filepath contained in REQUESTS_CA_BUNDLE for extra CA cert
+      export REQUESTS_CA_BUNDLE=/tmp/root-ca-cert.crt
+    fi
+fi
+
 # Gather all domains into a plaintext file
 DOMAIN_ARR=()
 for line in $DOMAINS; do
@@ -110,7 +123,7 @@ else
     certbot certonly --non-interactive --keep-until-expiring --expand \
         --email "$EMAIL" --agree-tos \
         --config-dir "$CERT_DIR" --work-dir "$WORK_DIR" \
-        --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" --standalone
+        --preferred-challenges "$CHALLENGE" "${DOMAIN_ARR[@]}" "${ACME_CUSTOM_SERVER_ARGUMENTS[@]}" --standalone
 fi
 
 # Get the last modified cert directory and copy the cert and private key to store


### PR DESCRIPTION
This PR adds an option to generate a certificate for people using a custom ACME server (usually, folks having their own PKI).

It leverages the `--server` option of the `certbot` CLI and the ability to set a custom root CA to trust using the `REQUESTS_CA_BUNDLE` env variable.

This enables a user to generate https certs for an instance that is not connected or exposed to the internet.

*I could add a link to a blog article describing how to set up the custom ACME server but I don't know what is the policy on outside links.*