### PR TITLE
Fix optional instance parameter

### DIFF
--- a/zwave/CHANGELOG.md
+++ b/zwave/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.1
+
+- Fix optional instance parameter
+
 ## 0.4.0
 
 - Add OZW instance ID configuration option

--- a/zwave/config.json
+++ b/zwave/config.json
@@ -1,6 +1,6 @@
 {
   "name": "OpenZWave",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "slug": "zwave",
   "description": "Control a ZWave network with Home Assistant",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],
@@ -36,7 +36,7 @@
   "schema": {
     "device": "str",
     "network_key": "password",
-    "instance": "int(1,)"
+    "instance": "int(1,)?"
   },
   "image": "homeassistant/{arch}-addon-zwave"
 }


### PR DESCRIPTION
Accidentally left a change behind.

This PR fixes the optional instance configuration parameter. It should have been optional, now causing error when trying to save the default configuration.