### PR TITLE
Bump deCONZ to 2.05.78

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.3.6
+
+- Bump deCONZ to 2.05.78
+
 ## 5.3.5
 
 - Downgrade deCONZ to 2.05.75, since it has been reported that 2.05.77, and possibly also 2.05.76, is causing issues for several users.

--- a/deconz/build.json
+++ b/deconz/build.json
@@ -5,6 +5,6 @@
     "armhf": "homeassistant/armhf-base-raspbian:stretch"
   },
   "args": {
-    "DECONZ_VERSION": "2.05.75"
+    "DECONZ_VERSION": "2.05.78"
   }
 }

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "slug": "deconz",
   "description": "Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],


### PR DESCRIPTION
Bump deCONZ to 2.05.78

Release notes: https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/V2_05_78

Resolves: #1428 #1431 