### PR TITLE
mariadb: Alpine 3.12, increase innodb_buffer_pool_size

### DIFF
--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.0
+
+- Upgrade Alpine Linux to 3.12
+- Increase innodb_buffer_pool_size to 128M
+
 ## 2.1.2
 
 - Fix S6-Overlay shutdown timeout

--- a/mariadb/build.json
+++ b/mariadb/build.json
@@ -1,10 +1,10 @@
 {
   "build_from": {
-    "aarch64": "homeassistant/aarch64-base:3.11",
-    "amd64": "homeassistant/amd64-base:3.11",
-    "armhf": "homeassistant/armhf-base:3.11",
-    "armv7": "homeassistant/armv7-base:3.11",
-    "i386": "homeassistant/i386-base:3.11"
+    "aarch64": "homeassistant/aarch64-base:3.12",
+    "amd64": "homeassistant/amd64-base:3.12",
+    "armhf": "homeassistant/armhf-base:3.12",
+    "armv7": "homeassistant/armv7-base:3.12",
+    "i386": "homeassistant/i386-base:3.12"
   },
   "args": {
     "JEMALLOC_VERSION": "5.2.1"

--- a/mariadb/config.json
+++ b/mariadb/config.json
@@ -1,6 +1,6 @@
 {
   "name": "MariaDB",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "slug": "mariadb",
   "description": "An SQL database server",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/mariadb",

--- a/mariadb/rootfs/etc/my.cnf.d/mariadb-server.cnf
+++ b/mariadb/rootfs/etc/my.cnf.d/mariadb-server.cnf
@@ -34,7 +34,7 @@ query_cache_type = 0
 
 # InnoDB Tweaks
 innodb_buffer_pool_instances = 1
-innodb_buffer_pool_size = 64M
+innodb_buffer_pool_size = 128M
 innodb_log_buffer_size = 8M
 innodb_log_file_size = 48M
 max_binlog_size = 96M


### PR DESCRIPTION
## 2.2.0

- Upgrade Alpine Linux to 3.12
- Increase innodb_buffer_pool_size to 128M

The increase of the innodb_buffer_pool_size from 64M -> 128M, will add 64M of additional memory usage to the add-on.

Table locks are stored in the InnoDB buffer pool and with 64M, it can run short and causes "1206: The total number of locks exceeds the lock table size" to be thrown. Especially when locks are quickly made after one another.

While 128M is not the holy grail, it should significantly reduce the risks of running into such an issue. In case it does happen, <https://github.com/home-assistant/core/pull/37228> triggers a retry.
