### PR TITLE
Don't delete the mariadb.sys yser

### DIFF
--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 2.2.1
+- Don't delete the mariadb.sys user, it's needed in MariaDB >= 10.4.13
 
 ## 2.2.0
 

--- a/mariadb/config.json
+++ b/mariadb/config.json
@@ -1,6 +1,6 @@
 {
   "name": "MariaDB",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "slug": "mariadb",
   "description": "An SQL database server",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/mariadb",

--- a/mariadb/rootfs/etc/services.d/mariadb/run
+++ b/mariadb/rootfs/etc/services.d/mariadb/run
@@ -45,12 +45,12 @@ if bashio::var.true "${NEW_INSTALL}"; then
         DELETE FROM
             mysql.user
         WHERE
-            user NOT IN ('mysql.sys', 'mysqlxsys', 'root', 'mysql', 'proxies_priv')
+            user NOT IN ('mysql.sys', 'mariadb.sys', 'mysqlxsys', 'root', 'mysql', 'proxies_priv')
                 OR host NOT IN ('localhost');
         DELETE FROM
             mysql.proxies_priv
         WHERE
-            user NOT IN ('mysql.sys', 'mysqlxsys', 'root', 'mysql', 'proxies_priv')
+            user NOT IN ('mysql.sys', 'mariadb.sys', 'mysqlxsys', 'root', 'mysql', 'proxies_priv')
                 OR host NOT IN ('localhost');
         DROP DATABASE IF EXISTS test;
         FLUSH PRIVILEGES;


### PR DESCRIPTION
Since MariaDB 10.4.13 `mysql.user` (and probably others) have a new definer `mariadb.sys` instead of `mysql.sys` that should be added to the list of users which are retained when MariaDB is set up.

The Docker library has fixed their bootstrap code in https://github.com/docker-library/mariadb/pull/306 - this change applies the same fix here.

Deleting the `mariadb.sys` user causes a problem when selecting from the `user` table, and may cause issues when MariaDB is upgraded. If so, the following can be used to restore the user:
```sql
insert into mysql.global_priv values ('localhost','mariadb.sys','{"access":0,"plugin":"mysql_native_password","authentication_string":"","account_locked":true,"password_last_changed":0}');
flush privileges;
```