### PR TITLE
OpenZWave: Roll-back alpine, adjust open-zwave commit

### DIFF
--- a/zwave/CHANGELOG.md
+++ b/zwave/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.1
+
+- Roll-back alpine to 3.11 and qt 5.12
+- Roll-back OpenZWave to 6c2ca613
+
 ## 0.5.0
 
 - Update OpenZWave to 5d3978d5

--- a/zwave/build.json
+++ b/zwave/build.json
@@ -1,16 +1,16 @@
 {
-	"build_from": {
-		"amd64": "homeassistant/amd64-base:3.11",
-		"i386": "homeassistant/i386-base:3.11",
-		"armhf": "homeassistant/armhf-base:3.11",
-		"armv7": "homeassistant/armv7-base:3.11",
-		"aarch64": "homeassistant/aarch64-base:3.11"
-	},
-	"args": {
-		"OZW_VERSION": "6c2ca6131cbba4200460256293d719053107a9e8",
-		"QTOZW_VERSION": "3ad9138f40a856366a7d85fb110b1ed91e1534a0",
-		"QTOZWADMIN_VERSION": "da04ebfbadc57484c487ebc846431eb283e83176",
-		"QTMQTT_VERSION": "5.12.8",
-		"QTWEBSOCKETS_VERSION": "5.12.8"
-	}
+  "build_from": {
+    "amd64": "homeassistant/amd64-base:3.11",
+    "i386": "homeassistant/i386-base:3.11",
+    "armhf": "homeassistant/armhf-base:3.11",
+    "armv7": "homeassistant/armv7-base:3.11",
+    "aarch64": "homeassistant/aarch64-base:3.11"
+  },
+  "args": {
+    "OZW_VERSION": "6c2ca6131cbba4200460256293d719053107a9e8",
+    "QTOZW_VERSION": "3ad9138f40a856366a7d85fb110b1ed91e1534a0",
+    "QTOZWADMIN_VERSION": "da04ebfbadc57484c487ebc846431eb283e83176",
+    "QTMQTT_VERSION": "5.12.8",
+    "QTWEBSOCKETS_VERSION": "5.12.8"
+  }
 }

--- a/zwave/build.json
+++ b/zwave/build.json
@@ -1,16 +1,16 @@
 {
-  "build_from": {
-    "amd64": "homeassistant/amd64-base:3.12",
-    "i386": "homeassistant/i386-base:3.12",
-    "armhf": "homeassistant/armhf-base:3.12",
-    "armv7": "homeassistant/armv7-base:3.12",
-    "aarch64": "homeassistant/aarch64-base:3.12"
-  },
-  "args": {
-    "OZW_VERSION": "5d3978d5cac8d1bf556bd20c56ec2309b7cd7091",
-    "QTOZW_VERSION": "3ad9138f40a856366a7d85fb110b1ed91e1534a0",
-    "QTOZWADMIN_VERSION": "da04ebfbadc57484c487ebc846431eb283e83176",
-    "QTMQTT_VERSION": "5.14.2",
-    "QTWEBSOCKETS_VERSION": "5.14.2"
-  }
+	"build_from": {
+		"amd64": "homeassistant/amd64-base:3.11",
+		"i386": "homeassistant/i386-base:3.11",
+		"armhf": "homeassistant/armhf-base:3.11",
+		"armv7": "homeassistant/armv7-base:3.11",
+		"aarch64": "homeassistant/aarch64-base:3.11"
+	},
+	"args": {
+		"OZW_VERSION": "6c2ca6131cbba4200460256293d719053107a9e8",
+		"QTOZW_VERSION": "3ad9138f40a856366a7d85fb110b1ed91e1534a0",
+		"QTOZWADMIN_VERSION": "da04ebfbadc57484c487ebc846431eb283e83176",
+		"QTMQTT_VERSION": "5.12.8",
+		"QTWEBSOCKETS_VERSION": "5.12.8"
+	}
 }

--- a/zwave/config.json
+++ b/zwave/config.json
@@ -1,42 +1,57 @@
 {
-	"name": "OpenZWave",
-	"version": "0.5.1",
-	"slug": "zwave",
-	"description": "Control a ZWave network with Home Assistant",
-	"arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],
-	"url": "https://github.com/home-assistant/hassio-addons/tree/master/zwave",
-	"ingress": true,
-	"ingress_entry": "vnc_lite.html",
-	"panel_icon": "mdi:z-wave",
-	"panel_title": "OpenZWave",
-	"startup": "services",
-	"boot": "auto",
-	"init": false,
-	"stage": "experimental",
-	"homeassistant": "0.110.0.dev",
-	"ports": {
-		"1983/tcp": null,
-		"5900/tcp": null
-	},
-	"ports_description": {
-		"1983/tcp": "ozw-admin port",
-		"5900/tcp": "VNC port"
-	},
-	"services": ["mqtt:want"],
-	"discovery": ["ozw"],
-	"auto_uart": true,
-	"gpio": true,
-	"apparmor": false,
-	"privileged": ["SYS_RAWIO"],
-	"devices": ["/dev/bus/usb:/dev/bus/usb:rwm", "/dev/mem:/dev/mem:rw"],
-	"options": {
-		"device": null,
-		"network_key": ""
-	},
-	"schema": {
-		"device": "str",
-		"network_key": "password",
-		"instance": "int(1,)?"
-	},
-	"image": "homeassistant/{arch}-addon-zwave"
+  "name": "OpenZWave",
+  "version": "0.5.1",
+  "slug": "zwave",
+  "description": "Control a ZWave network with Home Assistant",
+  "arch": [
+    "amd64",
+    "i386",
+    "armhf",
+    "armv7",
+    "aarch64"
+  ],
+  "url": "https://github.com/home-assistant/hassio-addons/tree/master/zwave",
+  "ingress": true,
+  "ingress_entry": "vnc_lite.html",
+  "panel_icon": "mdi:z-wave",
+  "panel_title": "OpenZWave",
+  "startup": "services",
+  "boot": "auto",
+  "init": false,
+  "stage": "experimental",
+  "homeassistant": "0.110.0.dev",
+  "ports": {
+    "1983/tcp": null,
+    "5900/tcp": null
+  },
+  "ports_description": {
+    "1983/tcp": "ozw-admin port",
+    "5900/tcp": "VNC port"
+  },
+  "services": [
+    "mqtt:want"
+  ],
+  "discovery": [
+    "ozw"
+  ],
+  "auto_uart": true,
+  "gpio": true,
+  "apparmor": false,
+  "privileged": [
+    "SYS_RAWIO"
+  ],
+  "devices": [
+    "/dev/bus/usb:/dev/bus/usb:rwm",
+    "/dev/mem:/dev/mem:rw"
+  ],
+  "options": {
+    "device": null,
+    "network_key": ""
+  },
+  "schema": {
+    "device": "str",
+    "network_key": "password",
+    "instance": "int(1,)?"
+  },
+  "image": "homeassistant/{arch}-addon-zwave"
 }

--- a/zwave/config.json
+++ b/zwave/config.json
@@ -1,42 +1,42 @@
 {
-  "name": "OpenZWave",
-  "version": "0.5.0",
-  "slug": "zwave",
-  "description": "Control a ZWave network with Home Assistant",
-  "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],
-  "url": "https://github.com/home-assistant/hassio-addons/tree/master/zwave",
-  "ingress": true,
-  "ingress_entry": "vnc_lite.html",
-  "panel_icon": "mdi:z-wave",
-  "panel_title": "OpenZWave",
-  "startup": "services",
-  "boot": "auto",
-  "init": false,
-  "stage": "experimental",
-  "homeassistant": "0.110.0.dev",
-  "ports": {
-    "1983/tcp": null,
-    "5900/tcp": null
-  },
-  "ports_description": {
-    "1983/tcp": "ozw-admin port",
-    "5900/tcp": "VNC port"
-  },
-  "services": ["mqtt:want"],
-  "discovery": ["ozw"],
-  "auto_uart": true,
-  "gpio": true,
-  "apparmor": false,
-  "privileged": ["SYS_RAWIO"],
-  "devices": ["/dev/bus/usb:/dev/bus/usb:rwm", "/dev/mem:/dev/mem:rw"],
-  "options": {
-    "device": null,
-    "network_key": ""
-  },
-  "schema": {
-    "device": "str",
-    "network_key": "password",
-    "instance": "int(1,)?"
-  },
-  "image": "homeassistant/{arch}-addon-zwave"
+	"name": "OpenZWave",
+	"version": "0.5.1",
+	"slug": "zwave",
+	"description": "Control a ZWave network with Home Assistant",
+	"arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],
+	"url": "https://github.com/home-assistant/hassio-addons/tree/master/zwave",
+	"ingress": true,
+	"ingress_entry": "vnc_lite.html",
+	"panel_icon": "mdi:z-wave",
+	"panel_title": "OpenZWave",
+	"startup": "services",
+	"boot": "auto",
+	"init": false,
+	"stage": "experimental",
+	"homeassistant": "0.110.0.dev",
+	"ports": {
+		"1983/tcp": null,
+		"5900/tcp": null
+	},
+	"ports_description": {
+		"1983/tcp": "ozw-admin port",
+		"5900/tcp": "VNC port"
+	},
+	"services": ["mqtt:want"],
+	"discovery": ["ozw"],
+	"auto_uart": true,
+	"gpio": true,
+	"apparmor": false,
+	"privileged": ["SYS_RAWIO"],
+	"devices": ["/dev/bus/usb:/dev/bus/usb:rwm", "/dev/mem:/dev/mem:rw"],
+	"options": {
+		"device": null,
+		"network_key": ""
+	},
+	"schema": {
+		"device": "str",
+		"network_key": "password",
+		"instance": "int(1,)?"
+	},
+	"image": "homeassistant/{arch}-addon-zwave"
 }


### PR DESCRIPTION
A number of users have reported issues with ozw-admin crashing after the 0.5.0 addon update, which sometimes crashes the entire container and requires it to be restarted.

I talked with Fishwaldo and we believe the issue is related to the alpine upgrade since it upgraded QT 5.12 to 5.14, and Fishwaldo is targeting QT 5.12 for the current ozw-admin and qt-openzwave builds.

I rolled back the alpine update and qt versions and have not experienced any crashes or issues on my machine over a few hours of testing today.

This also rolls open-zwave back a few commits, as there were some issues with the last couple commits that were included in the original update related to transitions and value refreshes. The following commits are reversed: https://github.com/OpenZWave/open-zwave/compare/6c2ca6131cbba4200460256293d719053107a9e8...5d3978d5cac8d1bf556bd20c56ec2309b7cd7091