### PR TITLE
deCONZ 6.1.1; Fix VNC on arm & Ledvance downloader

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.1.1
+
+- Fix LEDVANCE / OSRAM otau firmware downloader to restart each 65 seconds
+- Fix issue with VNC not starting on armhf, armv7 & aarch64 based systems
+
 ## 6.1.0
 
 - Fix issue with armhf / move back to raspbian

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "slug": "deconz",
   "description": "Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],
@@ -29,9 +29,7 @@
   "apparmor": false,
   "privileged": ["SYS_MODULE", "SYS_RAWIO"],
   "devices": ["/dev/bus/usb:/dev/bus/usb:rwm", "/dev/mem:/dev/mem:rw"],
-  "snapshot_exclude": [
-    "/data/otau/*"
-  ],
+  "snapshot_exclude": ["/data/otau/*"],
   "options": {
     "device": null,
     "vnc_password": ""

--- a/deconz/rootfs/etc/services.d/deconz/run
+++ b/deconz/rootfs/etc/services.d/deconz/run
@@ -49,7 +49,7 @@ if bashio::var.has_value "${VNC_PORT}"; then
     PLATFORM="xcb"
 
     # Fix tigervnc for 32 bits ARM
-    if [[ "armhf aarch64" = *"${ARCH}"* ]]; then
+    if [[ "armhf armv7" = *"${ARCH}"* ]]; then
         export LD_PRELOAD=/lib/arm-linux-gnueabihf/libgcc_s.so.1
     fi
 

--- a/deconz/rootfs/etc/services.d/deconz/run
+++ b/deconz/rootfs/etc/services.d/deconz/run
@@ -42,10 +42,21 @@ bashio::config.has_value 'dbg_zdp' \
 PLATFORM="minimal"
 VNC_PORT="$(bashio::addon.port 5900)"
 if bashio::var.has_value "${VNC_PORT}"; then
+    ARCH="$(bashio::info.arch)"
     TMP_FOLDER=$(mktemp -d)
     export XDG_RUNTIME_DIR="${TMP_FOLDER}"
     export DISPLAY=":0"
     PLATFORM="xcb"
+
+    # Fix tigervnc for 32 bits ARM
+    if [[ "armhf aarch64" = *"${ARCH}"* ]]; then
+        export LD_PRELOAD=/lib/arm-linux-gnueabihf/libgcc_s.so.1
+    fi
+
+    # Fix tigervnc for 64 bits ARM
+    if [[ "aarch64" = "${ARCH}" ]]; then
+        export LD_PRELOAD=/lib/aarch64-linux-gnu/libgcc_s.so.1
+    fi
 
     bashio::log.info "Starting VNC server..."
     tigervncserver \

--- a/deconz/rootfs/etc/services.d/otau-ledvance/run
+++ b/deconz/rootfs/etc/services.d/otau-ledvance/run
@@ -32,7 +32,7 @@ for (( i=0; i < "${OSRAM_DATA_SIZE}"; i++ )); do
     if [ "$((DL_DONE % 10))" == "0" ]; then
         # LEDVANCE/OSRAM API RateLimits : The rate limit 10 calls per 60 seconds or quota 100 MB per month.
         DL_DONE=0
-        exec sleep 65
+        sleep 65
     fi
 done
 


### PR DESCRIPTION
## 6.1.1

- Fix LEDVANCE / OSRAM otau firmware downloader to restart each 65 seconds
- Fix issue with VNC not starting on armhf, armv7 & aarch64 based systems

fixes #1480 