### PR TITLE
Improve DNS-OVH documentation

### DIFF
--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -277,7 +277,31 @@ dns:
 ```
 
 ### OVH
-Access to https://eu.api.ovh.com/createToken/ to create the required keys. (Use https://ca.api.ovh.com/createToken/ for north america region)
+You will need to generate an OVH API Key first at https://eu.api.ovh.com/createToken/ (for Europe) or https://ca.api.ovh.com/createToken/ (for north america). 
+
+When creating the API Key, you must ensure that the following rights are granted:
+* ``GET /domain/zone/*``
+* ``PUT /domain/zone/*``
+* ``POST /domain/zone/*``
+* ``DELETE /domain/zone/*``
+
+Example configuration
+```yaml
+email: hello@home-assistant.io
+domains:
+  - home-assistant.io
+certfile: fullchain.pem
+keyfile: privkey.pem
+challenge: dns
+dns:
+  provider: dns-ovh
+  ovh_endpoint: ovh-eu
+  ovh_application_key: 0123456789abcdef0123456789abcdef01234
+  ovh_application_secret: 0123456789abcdef0123456789abcdef01234
+  ovh_consumer_key: 0123456789abcdef0123456789abcdef01234
+```
+Use `ovh_endpoint: ovh-ca` for north america region.
+
 
 ## Certificate files
 


### PR DESCRIPTION
Give more details about the API Key requirements for DNS challenge with OVH, following [certbot documentation](https://certbot-dns-ovh.readthedocs.io/en/stable/). 
Added example configuration and details about api_endpoint.