### PR TITLE
Allow configurable hostname for hassio mqtt calls

### DIFF
--- a/mosquitto/config.json
+++ b/mosquitto/config.json
@@ -26,7 +26,10 @@
     },
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
-    "require_certificate": false
+    "require_certificate": false,
+    "hassio": {
+      "hostname": "hassio"
+    }
   },
   "schema": {
     "logins": [{ "username": "str", "password": "str" }],
@@ -38,6 +41,9 @@
     "cafile": "str?",
     "certfile": "str",
     "keyfile": "str",
+    "hassio": {
+      "hostname": "str"
+    },
     "require_certificate": "bool"
   },
   "image": "homeassistant/{arch}-addon-mosquitto"

--- a/mosquitto/data/run.sh
+++ b/mosquitto/data/run.sh
@@ -11,6 +11,7 @@ CERTFILE=$(jq --raw-output ".certfile" $CONFIG_PATH)
 CAFILE=$(jq --raw-output --exit-status ".cafile | select (.!=null)" $CONFIG_PATH || echo "$CERTFILE")
 REQUIRE_CERTIFICATE=$(jq --raw-output ".require_certificate" $CONFIG_PATH)
 CUSTOMIZE_ACTIVE=$(jq --raw-output ".customize.active" $CONFIG_PATH)
+HASSIO_HOSTNAME=$(jq --raw-output ".hassio.hostname" $CONFIG_PATH)
 LOGGING=$(bashio::info 'hassio.info.logging' '.logging')
 HOMEASSISTANT_PW=
 ADDONS_PW=
@@ -45,7 +46,7 @@ function call_hassio() {
     local token=
 
     token="X-Hassio-Key: ${HASSIO_TOKEN}"
-    url="http://hassio/${path}"
+    url="http://${HASSIO_HOSTNAME}/${path}"
 
     # Call API
     if [ -n "${data}" ]; then


### PR DESCRIPTION
I'm wanting to use the docker image in a home assistant environment on kubernetes. The hardcoded hostname makes this difficult to do. Adding an option so users can change it. 