### PR TITLE
check_config: Upgrade base image to 8.1.0

### DIFF
--- a/check_config/CHANGELOG.md
+++ b/check_config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.0
+
+- Update base image to version 8.1.0
+
 ## 3.3.0
 
 - Update base image to version 7.2.0

--- a/check_config/build.json
+++ b/check_config/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "homeassistant/aarch64-homeassistant-base:7.2.0",
-    "amd64": "homeassistant/amd64-homeassistant-base:7.2.0",
-    "armhf": "homeassistant/armhf-homeassistant-base:7.2.0",
-    "armv7": "homeassistant/armv7-homeassistant-base:7.2.0",
-    "i386": "homeassistant/i386-homeassistant-base:7.2.0"
+    "aarch64": "homeassistant/aarch64-homeassistant-base:8.1.0",
+    "amd64": "homeassistant/amd64-homeassistant-base:8.1.0",
+    "armhf": "homeassistant/armhf-homeassistant-base:8.1.0",
+    "armv7": "homeassistant/armv7-homeassistant-base:8.1.0",
+    "i386": "homeassistant/i386-homeassistant-base:8.1.0"
   }
 }

--- a/check_config/config.json
+++ b/check_config/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Check Home Assistant configuration",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "slug": "check_config",
   "description": "Check current Home Assistant configuration against a new version",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/check_config",


### PR DESCRIPTION
Upgrades the base image to 8.1.0, so we have Python 3.8.

fixes #1502