### PR TITLE
Cleanup zwave from remove ABI tags

### DIFF
--- a/zwave/Dockerfile
+++ b/zwave/Dockerfile
@@ -83,8 +83,6 @@ RUN \
     && make -j $(( $(nproc) + 1 )) \
     && make install \
     \
-    && strip --remove-section=.note.ABI-tag /usr/lib/libQt5Core.so \
-    \
     && mkdir -p /usr/share/OpenZWave \
     && mv /usr/share/qt5/qt-openzwavedatabase.rcc /usr/share/OpenZWave/ \
     \


### PR DESCRIPTION
QT >= 5.10  need linux kernel >= 3.17 - all 3.x kernel are anyway all EOL. We follow our decision from deCONZ.

This is a hack and not needed for our supported systems aka ADR011