### PR TITLE
Bump deCONZ to 2.05.80

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.2.4
+
+- Bump deCONZ to 2.05.80
+
 ## 6.2.3
 
 - Add background color to the ingress entry page

--- a/deconz/build.json
+++ b/deconz/build.json
@@ -5,6 +5,6 @@
     "armhf": "homeassistant/armhf-base-raspbian:buster"
   },
   "args": {
-    "DECONZ_VERSION": "2.05.79"
+    "DECONZ_VERSION": "2.05.80"
   }
 }

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "slug": "deconz",
   "description": "Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],


### PR DESCRIPTION
Bump deCONZ to 2.05.78

Release notes: https://github.com/dresden-elektronik/deconz-rest-plugin/releases/tag/V2_05_80