### PR TITLE
Bump deCONZ to 2.05.81

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.2.4
+
+- Bump deCONZ to 2.05.81
+
 ## 6.2.3
 
 - Add background color to the ingress entry page

--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.2.4
+## 6.3.0
 
 - Bump deCONZ to 2.05.81
 

--- a/deconz/Dockerfile
+++ b/deconz/Dockerfile
@@ -61,12 +61,12 @@ RUN apt-get update \
 ARG DECONZ_VERSION
 RUN if [ "${BUILD_ARCH}" = "armhf" ]; \
         then \
-            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/raspbian/beta/deconz-${DECONZ_VERSION}-qt5.deb; \
+            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/raspbian/stable/deconz-${DECONZ_VERSION}-qt5.deb; \
         elif [ "${BUILD_ARCH}" = "aarch64" ]; \
         then \
             curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/raspbian/alpha/deconz_${DECONZ_VERSION}-debian-stretch-beta_arm64.deb; \
         else \
-            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/ubuntu/beta/deconz-${DECONZ_VERSION}-qt5.deb; \
+            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/ubuntu/stable/deconz-${DECONZ_VERSION}-qt5.deb; \
         fi \
     && dpkg --force-all -i /deconz.deb \
     && rm -f /deconz.deb \

--- a/deconz/Dockerfile
+++ b/deconz/Dockerfile
@@ -64,7 +64,7 @@ RUN if [ "${BUILD_ARCH}" = "armhf" ]; \
             curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/raspbian/stable/deconz-${DECONZ_VERSION}-qt5.deb; \
         elif [ "${BUILD_ARCH}" = "aarch64" ]; \
         then \
-            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/debian/stable/deconz_${DECONZ_VERSION}-debian-stretch_arm64.deb; \
+            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/debian/stable/deconz_${DECONZ_VERSION}-debian-stretch-stable_arm64.deb; \
         else \
             curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/ubuntu/stable/deconz-${DECONZ_VERSION}-qt5.deb; \
         fi \

--- a/deconz/Dockerfile
+++ b/deconz/Dockerfile
@@ -64,7 +64,7 @@ RUN if [ "${BUILD_ARCH}" = "armhf" ]; \
             curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/raspbian/stable/deconz-${DECONZ_VERSION}-qt5.deb; \
         elif [ "${BUILD_ARCH}" = "aarch64" ]; \
         then \
-            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/raspbian/alpha/deconz_${DECONZ_VERSION}-debian-stretch-beta_arm64.deb; \
+            curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/debian/stable/deconz_${DECONZ_VERSION}-debian-stretch_arm64.deb; \
         else \
             curl -q -L -o /deconz.deb http://deconz.dresden-elektronik.de/ubuntu/stable/deconz-${DECONZ_VERSION}-qt5.deb; \
         fi \

--- a/deconz/build.json
+++ b/deconz/build.json
@@ -5,6 +5,6 @@
     "armhf": "homeassistant/armhf-base-raspbian:buster"
   },
   "args": {
-    "DECONZ_VERSION": "2.05.79"
+    "DECONZ_VERSION": "2.05.81"
   }
 }

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "slug": "deconz",
   "description": "Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "6.2.4",
+  "version": "6.3.0",
   "slug": "deconz",
   "description": "Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],


### PR DESCRIPTION
Bump deCONZ to 2.05.81

Release notes: https://github.com/dresden-elektronik/deconz-rest-plugin/tree/V2_05_81_stable