### PR TITLE
Revert OpenZWave add-on release 0.5.3

### DIFF
--- a/zwave/CHANGELOG.md
+++ b/zwave/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 0.5.3
-
--  Update Openzwave to 7eaae21
-
 ## 0.5.2
 
 - Fix startup failure due to stray OZW Daemon status retained in MQTT

--- a/zwave/Dockerfile
+++ b/zwave/Dockerfile
@@ -39,7 +39,6 @@ RUN \
         curl-dev \
         eudev-dev \
         git \
-        pkgconf-dev \
         openssl-dev \
         qt5-qtbase-dev \
         qt5-qtremoteobjects-dev \

--- a/zwave/build.json
+++ b/zwave/build.json
@@ -7,7 +7,7 @@
     "aarch64": "homeassistant/aarch64-base:3.11"
   },
   "args": {
-    "OZW_VERSION": "7eaae21b3248a82f841900a27ec9702d144f53cc",
+    "OZW_VERSION": "6cf372959ee88baabfe68742297e7b13f57fef14",
     "QTOZW_VERSION": "3ad9138f40a856366a7d85fb110b1ed91e1534a0",
     "QTOZWADMIN_VERSION": "da04ebfbadc57484c487ebc846431eb283e83176",
     "QTMQTT_VERSION": "5.12.8",

--- a/zwave/config.json
+++ b/zwave/config.json
@@ -1,6 +1,6 @@
 {
   "name": "OpenZWave",
-  "version": "0.5.3",
+  "version": "0.5.2",
   "slug": "zwave",
   "description": "Control a ZWave network with Home Assistant",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
- 0.5.3 failed to build on three architectures.
- Revert it for now as release 0.5.4.

This reverts commit b402ea84baf061d6ea4a6ae68ef5729d726a8ef6.