### PR TITLE
Add missing pip in Alpine 3.12

### DIFF
--- a/configurator/Dockerfile
+++ b/configurator/Dockerfile
@@ -8,6 +8,7 @@ RUN \
     apk add --no-cache \
         git \
         openssh-client \
+        py3-pip \
         python3 \
     && pip3 install \
         --no-cache-dir \


### PR DESCRIPTION
Add missing pip in the latest version of the Configurator.