### PR TITLE
Roll back zwave add-on to 0.5.2

### DIFF
--- a/zwave/config.json
+++ b/zwave/config.json
@@ -1,6 +1,6 @@
 {
   "name": "OpenZWave",
-  "version": "0.6.0",
+  "version": "0.5.2",
   "slug": "zwave",
   "description": "Control a ZWave network with Home Assistant",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],


### PR DESCRIPTION
- After the build troubles with 0.5.3 and vnc troubles with 0.6.0, we've decided to roll back the add-on to 0.5.2.
- We'll freeze updates until the current version (0.6.0) is fixed.