### PR TITLE
letsencrypt: Add support for manual hook scripts.

### DIFF
--- a/letsencrypt/CHANGELOG.md
+++ b/letsencrypt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.12.0
+
+- Add support for custom Certbot auth and cleanup hooks
+
 ## 4.11.0
 
 - Add support for Njalla DNS

--- a/letsencrypt/DOCS.md
+++ b/letsencrypt/DOCS.md
@@ -61,6 +61,8 @@ dnsmadeeasy_secret_key: ''
 google_creds: ''
 gehirn_api_token: ''
 gehirn_api_secret: ''
+hook_script_auth: ''
+hook_script_cleanup: ''
 linode_key: ''
 linode_version: ''
 luadns_email: ''
@@ -321,6 +323,43 @@ dns:
 ```
 Use `ovh_endpoint: ovh-ca` for north America region.
 
+### Hook Script
+
+If your DNS provider isn't directly supported by Certbot, but has an API, you may be able to use an
+[authentication hook script](https://certbot.eff.org/docs/using.html#hooks) to update DNS automatically.
+Some DNS providers, such as [deSEC](https://github.com/desec-utils/certbot-hook) and
+[acme-dns](https://github.com/joohoi/acme-dns-certbot-joohoi), have published official Certbot hook scripts.
+For other providers, you may be able to find a community hook script, or you can write one yourself.
+
+To use hook scripts, you will need to upload them to the `/share` or `/ssl` directory. You can use
+the Samba or SSH add-ons to do this. You may need to modify the hook scripts, or include other files along
+with the scripts, to properly set your API key or other credentials. Follow the instructions that came
+with your hook script if you're not sure.
+
+Once your hook scripts are configured and uploaded, configure the addon as follows:
+
+```yaml
+email: your.email@example.com
+domains:
+  - home-assistant.io
+certfile: fullchain.pem
+keyfile: privkey.pem
+challenge: dns
+dns:
+  provider: dns-hook-script
+  hook_script_auth: /share/path/to/your/auth-hook.sh
+  hook_script_cleanup: /share/path/to/your/cleanup-hook.sh
+```
+
+Some hook scripts use the same script for both the auth and cleanup hooks. If this is the case for your
+hook script, put the same path in both `hook_script_auth` and `hook_script_cleanup`:
+
+```yaml
+dns:
+  provider: dns-hook-script
+  hook_script_auth: /share/path/to/your/hook.sh
+  hook_script_cleanup: /share/path/to/your/hook.sh
+```
 
 ## Certificate files
 

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -13,6 +13,7 @@ RUN apk add --no-cache --update \
         libffi \
         musl \
         openssl \
+        curl \
     && apk add --no-cache --virtual .build-dependencies \
         g++ \
         libffi-dev \
@@ -21,6 +22,7 @@ RUN apk add --no-cache --update \
     && pip3 install --no-cache-dir --find-links \
         "https://wheels.home-assistant.io/alpine-$(cut -d '.' -f 1-2 < /etc/alpine-release)/${BUILD_ARCH}/" \
         certbot==${CERTBOT_VERSION} \
+        requests \
         certbot-dns-cloudflare==${CERTBOT_VERSION} \
         certbot-dns-cloudxns==${CERTBOT_VERSION} \
         certbot-dns-digitalocean==${CERTBOT_VERSION} \

--- a/letsencrypt/config.json
+++ b/letsencrypt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Let's Encrypt",
-  "version": "4.11.0",
+  "version": "4.12.0",
   "slug": "letsencrypt",
   "description": "Manage certificate from Let's Encrypt",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/letsencrypt",
@@ -32,7 +32,7 @@
     "acme_server": "url?",
     "acme_root_ca_cert": "str?",
     "dns": {
-      "provider": "list(dns-cloudflare|dns-cloudxns|dns-digitalocean|dns-directadmin|dns-dnsimple|dns-dnsmadeeasy|dns-gehirn|dns-google|dns-linode|dns-luadns|dns-njalla|dns-nsone|dns-ovh|dns-rfc2136|dns-route53|dns-sakuracloud|dns-netcup|dns-gandi|dns-transip)?",
+      "provider": "list(dns-cloudflare|dns-cloudxns|dns-digitalocean|dns-directadmin|dns-dnsimple|dns-dnsmadeeasy|dns-gehirn|dns-google|dns-hook-script|dns-linode|dns-luadns|dns-njalla|dns-nsone|dns-ovh|dns-rfc2136|dns-route53|dns-sakuracloud|dns-netcup|dns-gandi|dns-transip)?",
       "propagation_seconds": "int(60,3600)?",
       "cloudflare_email": "email?",
       "cloudflare_api_key": "str?",
@@ -49,6 +49,8 @@
       "gehirn_api_token": "str?",
       "gehirn_api_secret": "str?",
       "google_creds": "str?",
+      "hook_script_auth": "str?",
+      "hook_script_cleanup": "str?",
       "linode_key": "str?",
       "linode_version": "str?",
       "luadns_email": "email?",

--- a/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
+++ b/letsencrypt/rootfs/etc/services.d/lets-encrypt/run
@@ -96,6 +96,12 @@ elif [ "${CHALLENGE}" == "dns" ] && [ "${DNS_PROVIDER}" == "dns-njalla" ]; then
     bashio::config.require 'dns.njalla_token'
     PROVIDER_ARGUMENTS+=("--authenticator" "certbot-dns-njalla:dns-njalla" "--certbot-dns-njalla:dns-njalla-credentials" /data/dnsapikey "--certbot-dns-njalla:dns-njalla-propagation-seconds" "${PROPAGATION_SECONDS}")
 
+# Manual hook script
+elif [ "${CHALLENGE}" == "dns" ] && [ "${DNS_PROVIDER}" == "dns-hook-script" ]; then
+    bashio::config.require 'dns.hook_script_auth'
+    bashio::config.require 'dns.hook_script_cleanup'
+    PROVIDER_ARGUMENTS+=("--manual" "--manual-public-ip-logging-ok" "--manual-auth-hook" "$(bashio::config 'dns.hook_script_auth')" "--manual-cleanup-hook" "$(bashio::config 'dns.hook_script_cleanup')")
+
 #All others
 else
     PROVIDER_ARGUMENTS+=("--${DNS_PROVIDER}" "--${DNS_PROVIDER}-credentials" /data/dnsapikey)


### PR DESCRIPTION
These are useful for smaller or self-hosted DNS providers that don't have official support in Certbot. Several of these providers already publish official hook scripts, allowing those providers to be supported without any additional changes to the add-on.

This adds `curl` and `requests` to the Dockerfile, but this should not increase the size of the container, since `curl` is already in the addon base image, and `requests` is used by Certbot itself. However, since most of the hook scripts that I found online seemed to use one or the other, it's worth calling them out explicitly.