### PR TITLE
Enable autoscale for DeCONZ noVNC

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.4.1
+
+- Enable autoscale for ingress noVNC
+
 ## 6.4.0
 
 - Bump deCONZ to 2.05.84

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "slug": "deconz",
   "description": "Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],

--- a/deconz/rootfs/usr/share/www/ingress.html
+++ b/deconz/rootfs/usr/share/www/ingress.html
@@ -292,7 +292,7 @@
               <span class="mdc-button__label">Phoscon</span>
             </button>
           </a>
-          <a href="novnc/vnc_lite.html">
+          <a href="novnc/vnc_lite.html?scale=yes">
             <button class="mdc-button mdc-button--raised">
               <div class="mdc-button__ripple"></div>
 


### PR DESCRIPTION
On the laptop it is difficult to use the noVNC page because it does not fit on the screen. I have activated the scaling for the noVNC plugin.