### PR TITLE
🔨Ignore DB files on copy for check_config

### DIFF
--- a/check_config/CHANGELOG.md
+++ b/check_config/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.6.0
+
+- Change to rsync for copy
+- Ignore HA db files
+
 ## 3.5.0
 
 - Update base image to version 8.4.0

--- a/check_config/Dockerfile
+++ b/check_config/Dockerfile
@@ -1,6 +1,8 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
+
 RUN apk add --no-cache \
         rsync
+
 # Copy data
 COPY rootfs /

--- a/check_config/Dockerfile
+++ b/check_config/Dockerfile
@@ -1,5 +1,6 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
-
+RUN apk add --no-cache \
+        rsync
 # Copy data
 COPY rootfs /

--- a/check_config/config.json
+++ b/check_config/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Check Home Assistant configuration",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "slug": "check_config",
   "description": "Check current Home Assistant configuration against a new version",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/check_config",

--- a/check_config/rootfs/etc/services.d/check-config/run
+++ b/check_config/rootfs/etc/services.d/check-config/run
@@ -29,7 +29,7 @@ bashio::log.info "Installed Home Assistant ${INSTALLED_VERSION##*=}"
 
 # Making a temporary copy of your configuration
 bashio::log.info "Making a copy of your configuration for checking..."
-cp -fr /config /tmp/config
+rsync -avr --exclude='*home-assistant_v2*' /config/ /tmp/config --quiet
 
 # Start configuration check
 bashio::log.info "Checking your configuration against this version..."


### PR DESCRIPTION
Moved cp to rsync as it is easier to ignore file patterns.

Tested and appears to work ok, hope I got the version config ok.

Closes #1495 