### PR TITLE
Add action to build changed add-ons

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: Build
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - master
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    name: Initialize builds
+    outputs:
+      files: ${{ steps.files.outputs.all }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - id: files
+        uses: jitterbit/get-changed-files@v1
+  build:
+    needs: init
+    runs-on: ubuntu-latest
+    name: Build ${{ matrix.addon }} add-on
+    strategy:
+      fail-fast: False
+      matrix:
+        addon:
+          - ada
+          - almond
+          - cec_scan
+          - check_config
+          - configurator
+          - deconz
+          - dhcp_server
+          - dnsmasq
+          - duckdns
+          - git_pull
+          - google_assistant
+          - homematic
+          - letsencrypt
+          - mariadb
+          - mosquitto
+          - nginx_proxy
+          - rpc_shutdown
+          - samba
+          - ssh
+          - tellstick
+          - zwave
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Check build for ${{ matrix.addon }}
+        run: |
+          if [[ "${{ needs.init.outputs.files }}" =~ "${{ matrix.addon }}" ]]; then
+
+            # Test build the add-on
+            docker run --rm --privileged \
+            -v /var/run/docker.sock:/var/run/docker.sock:ro \
+            -v ${PWD}/${{ matrix.addon }}:/data homeassistant/amd64-builder --all --target /data --test
+
+            # Show the finished images
+            docker images
+          else
+            echo "Files for ${{ matrix.addon }} did not change, skipping build check"
+          fi


### PR DESCRIPTION
Adds GitHub action to build add-ons that has changed files in a PR.

Example run with a file changed for the ssh add-on: <https://github.com/ludeeus/hassio-addons-1/runs/1271169501>
Example run with a failed build for nginx_proxy add-on: <https://github.com/ludeeus/hassio-addons-1/actions/runs/313791749>

When the build is done, `docker images` are executed so we can catch the new size of the images.