### PR TITLE
Fix example Home Assistant configuration

### DIFF
--- a/rpc_shutdown/DOCS.md
+++ b/rpc_shutdown/DOCS.md
@@ -64,7 +64,7 @@ Use the following inside Home Assistant service call to use it:
 
 ```yaml
 service: hassio.addon_stdin
-data:
+service_data:
   addon: core_rpc_shutdown
   input: test-pc
 ```


### PR DESCRIPTION
When setting up a config as a button within home assistant, the original Home Assistant configuration example provides an error "required key not provided @ data['platform']"
Changing the data: line to service_data: inline with other service calls functions as expected as well as not generating the error.