### PR TITLE
Clarify where to store the mosquitto certificate files

### DIFF
--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -70,15 +70,15 @@ The folder to read the additional configuration files (`*.conf`) from.
 
 ### Option: `cafile` (optional)
 
-A file containing a root certificate.
+A file containing a root certificate. Place this file in the Home Assistant `ssl` folder.
 
 ### Option: `certfile`
 
-A file containing a certificate, including its chain.
+A file containing a certificate, including its chain. Place this file in the Home Assistant `ssl` folder.
 
 ### Option: `keyfile`
 
-A file containing the private key.
+A file containing the private key. Place this file in the Home Assistant `ssl` folder.
 
 ### Option: `require_certificate`
 


### PR DESCRIPTION
I've wasted hours looking for where to store the certificate files for the mosquitto addon. This should hopefully clarify it for people using it in the future. See also https://github.com/home-assistant/hassio-addons/issues/950.

I've never created a pull request in my life, so I hope I do this right.