### PR TITLE
DuckDns script read config off ipv4 and ipv6 correctly

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.12.2
+
+- Rely on bashio to handle empty IPv4 / IPv6
+
 ## 1.12.1
 
 - Clean up dehydrated lock file at start also if no live cert exists

--- a/duckdns/config.json
+++ b/duckdns/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Duck DNS",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "slug": "duckdns",
   "description": "Free Dynamic DNS (DynDNS or DDNS) service with Let's Encrypt support",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/duckdns",

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -7,8 +7,8 @@ WORK_DIR=/data/workdir
 LE_UPDATE="0"
 
 # DuckDNS
-IPV4=$(bashio::config 'ipv4 // empty')
-IPV6=$(bashio::config 'ipv6 // empty')
+IPV4=$(bashio::config 'ipv4')
+IPV6=$(bashio::config 'ipv6')
 TOKEN=$(bashio::config 'token')
 DOMAINS=$(bashio::config 'domains | join(",")')
 WAIT_TIME=$(bashio::config 'seconds')


### PR DESCRIPTION
Configuring an ipv4 failed for me until i removed the ` // empty`. This is already added by bashio under the hood.