### PR TITLE
Set blank ipv4 and ipv6 in duckdns request if config is unset.

### DIFF
--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.12.3
+
+- Dont set IPv4 / IPv6 in duckdns request if config is unset
+
 ## 1.12.2
 
 - Rely on bashio to handle empty IPv4 / IPv6

--- a/duckdns/config.json
+++ b/duckdns/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Duck DNS",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "slug": "duckdns",
   "description": "Free Dynamic DNS (DynDNS or DDNS) service with Let's Encrypt support",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/duckdns",

--- a/duckdns/data/run.sh
+++ b/duckdns/data/run.sh
@@ -53,8 +53,8 @@ fi
 # Run duckdns
 while true; do
 
-    [[ ${IPV4} != *:/* ]] && ipv4=${IPV4} || ipv4=$(curl -s -m 10 "${IPV4}")
-    [[ ${IPV6} != *:/* ]] && ipv6=${IPV6} || ipv6=$(curl -s -m 10 "${IPV6}")
+    [[ ${IPV4} != *:/* ]] && ipv4="" || ipv4=$(curl -s -m 10 "${IPV4}")
+    [[ ${IPV6} != *:/* ]] && ipv6="" || ipv6=$(curl -s -m 10 "${IPV6}")
 
     if answer="$(curl -s "https://www.duckdns.org/update?domains=${DOMAINS}&token=${TOKEN}&ip=${ipv4}&ipv6=${ipv6}&verbose=true")"; then
         bashio::log.info "${answer}"


### PR DESCRIPTION
Fixes #1657 

Issue is, when config values are unset, not present om config, bashio resolves them to `"null"`.

This fix will pretty much ignore any configured value that does not look like an url.