### PR TITLE
Allow Configurator to skip git initialization

### DIFF
--- a/configurator/CHANGELOG.md
+++ b/configurator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.2.0
+
+- Add git option which allows disabling the (default) git initialization
+
 ## 5.1.0
 
 - Update base image to Alpine 3.12

--- a/configurator/DOCS.md
+++ b/configurator/DOCS.md
@@ -24,6 +24,7 @@ Add-on configuration:
 ```yaml
 dirsfirst: false
 enforce_basepath: false
+git: true
 ignore_pattern:
   - __pycache__
 ssh_keys: []
@@ -38,6 +39,10 @@ Set it to `true` to list directories first, `false` otherwise.
 ### Option: `enforce_basepath` (required)
 
 If set to `true`, access is limited to files within the `/config` directory.
+
+### Option: `git` (required)
+
+If set to `true`, add-on will initialize git for directories which support it.
 
 ### Option: `ignore_pattern` (required)
 

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -16,12 +16,14 @@
   "options": {
     "dirsfirst": false,
     "enforce_basepath": true,
+    "git": true,
     "ignore_pattern": ["__pycache__", ".cloud", ".storage", "deps"],
     "ssh_keys": []
   },
   "schema": {
     "dirsfirst": "bool",
     "enforce_basepath": "bool",
+    "git": "bool",
     "ignore_pattern": ["str"],
     "ssh_keys": ["str"]
   },

--- a/configurator/config.json
+++ b/configurator/config.json
@@ -1,6 +1,6 @@
 {
   "name": "File editor",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "slug": "configurator",
   "description": "Simple browser-based file editor for Home Assistant",
   "url": "https://github.com/home-assistant/hassio-addons/tree/master/configurator",

--- a/configurator/rootfs/etc/services.d/configurator/run
+++ b/configurator/rootfs/etc/services.d/configurator/run
@@ -4,8 +4,11 @@
 # ==============================================================================
 export HC_DIRSFIRST
 export HC_ENFORCE_BASEPATH
+export HC_GIT
 export HC_HASS_API_PASSWORD
 export HC_IGNORE_PATTERN
+
+bashio::log.info "Starting Configurator run script"
 
 # If any SSH key files are defined in the configuration options, add them for use by git
 if bashio::config.has_value "ssh_keys"; then
@@ -27,6 +30,7 @@ fi
 # Setup and run configurator
 HC_DIRSFIRST=$(bashio::config 'dirsfirst')
 HC_ENFORCE_BASEPATH=$(bashio::config 'enforce_basepath')
+HC_GIT=$(bashio::config 'git')
 HC_HASS_API_PASSWORD="${SUPERVISOR_TOKEN}"
 HC_IGNORE_PATTERN="$(bashio::config 'ignore_pattern | join(",")')"
 

--- a/configurator/rootfs/etc/services.d/configurator/run
+++ b/configurator/rootfs/etc/services.d/configurator/run
@@ -8,8 +8,6 @@ export HC_GIT
 export HC_HASS_API_PASSWORD
 export HC_IGNORE_PATTERN
 
-bashio::log.info "Starting Configurator run script"
-
 # If any SSH key files are defined in the configuration options, add them for use by git
 if bashio::config.has_value "ssh_keys"; then
   # Start the SSH agent


### PR DESCRIPTION
In some cases, although there is .git folder in the config folder, we should have a way to skip git initialization as it might fail. When it does it completely fails the loading of the configurator.
With this change the user can specify we should skip git initialization and therefore allow the configurator to work correctly.