### PR TITLE
Document how to enable the option to add a new user

### DIFF
--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -17,7 +17,10 @@ The add-on has a couple of options available. To get the add-on running:
 3. Check the add-on log output to see the result.
 
 Create a new user for MQTT via the **Configuration** -> **Users (manage users)**.
-Note: This name cannot be `homeassistant` or `addon`, those are reserved usernames.
+Notes:
+
+1. This name cannot be `homeassistant` or `addon`, those are reserved usernames.
+2. If you do not see the option to create a new user, ensure that **Advanced Mode** is enabled in your profile.
 
 To use the Mosquitto as a broker, go to the integration page and install the configuration with one click:
 


### PR DESCRIPTION
The documentation mentions that a new user should be created that will handle the MQTT messaging, but recent versions of Home Assistant disable the option to add new users by default. This is only available for users that have enabled "Advanced Mode".