### PR TITLE
Downgrade deCONZ to 2.05.84

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.5.1
+
+- Downgrade deCONZ to 2.05.84 since 2.05.88 is reportedly causing issues for several users.
+
 ## 6.5.0
 
 - Bump deCONZ to 2.05.88

--- a/deconz/build.json
+++ b/deconz/build.json
@@ -5,6 +5,6 @@
     "armhf": "homeassistant/armhf-base-raspbian:buster"
   },
   "args": {
-    "DECONZ_VERSION": "2.05.88"
+    "DECONZ_VERSION": "2.05.84"
   }
 }

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "deCONZ",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "slug": "deconz",
   "description": "Control a Zigbee network with ConBee or RaspBee by Dresden Elektronik",
   "arch": ["amd64", "armhf", "aarch64"],


### PR DESCRIPTION
After upgrading to version 6.5.0 of the deCONZ addon, it no longer works for me. I can connect to the web server, but the _Gateway_ page in the deCONZ settings show _Firmware: Not connected_, maybe indicating that the ZigBee device (RaspBee 1 in my case) is no longer detected correctly.

The following output appears in the logs:

```
12:33:13:816 failed to reconnect to network try=8
12:33:14:815 wait reconnect 4 seconds
12:33:14:870 dev /dev/ttyAMA0
```

<details>
libpng warning: iCCP: known incorrect sRGB profile
[11:32:09] INFO: Starting Nginx...
2020/11/14 11:32:09 [notice] 328#328: using the "epoll" event method
2020/11/14 11:32:09 [notice] 328#328: nginx/1.14.2
2020/11/14 11:32:09 [notice] 328#328: OS: Linux 4.19.127-v7l
2020/11/14 11:32:09 [notice] 328#328: getrlimit(RLIMIT_NOFILE): 1048576:1048576
2020/11/14 11:32:09 [notice] 328#328: start worker processes
2020/11/14 11:32:09 [notice] 328#328: start worker process 947
QObject::connect: Cannot queue arguments of type 'QTextBlock'
(Make sure 'QTextBlock' is registered using qRegisterMetaType().)
QObject::connect: Cannot queue arguments of type 'QTextCursor'
(Make sure 'QTextCursor' is registered using qRegisterMetaType().)
[12:32:19] INFO: Successfully send discovery information to Home Assistant.
12:32:08:889 HTTP Server listen on address 0.0.0.0, port: 40850, root: /usr/share/deCONZ/webapp/
12:32:08:923 CTRL. 3.27.212:32:09:025 dev /dev/ttyAMA0
12:32:09:069 dev /dev/ttyAMA0
12:32:09:070 ZCLDB init file /data/.local/share/dresden-elektronik/deCONZ/zcldb.txt
12:32:09:216 parent process s6-supervise
12:32:09:217 gw run mode: docker/hassio
12:32:09:217 GW sd-card image version file does not exist: /data/.local/share/dresden-elektronik/deCONZ/gw-version
12:32:09:217 sd-card cid: 035344534c33324780ffffffff00f400
12:32:09:219 DB sqlite version 3.27.2
12:32:09:220 DB PRAGMA page_count: 75
12:32:09:220 DB PRAGMA page_size: 4096
12:32:09:221 DB PRAGMA freelist_count: 5
12:32:09:221 DB file size 307200 bytes, free pages 5
12:32:09:221 DB PRAGMA user_version: 7
12:32:09:221 DB cleanup
12:32:09:222 DB create temporary views
12:32:09:280 remove sensor 66 from group 0x0002
12:32:09:280 started websocket server at port 8081
12:32:09:283 [INFO] - Found file containing button maps. Parsing data...
12:32:09:286 [ERROR] - Button map 'sunricherCCTMap' in JSON file has no assigned ModelIDs. Skip loading button map...
12:32:09:293 [INFO] - Button maps loaded.
12:32:09:295 dlg action: Read binding table
12:32:09:295 found node plugin: libde_rest_plugin.so - REST API Plugin
12:32:09:298 found node plugin: libde_signal_plugin.so - Signal Monitor Plugin
12:32:14:492 found node plugin: libstd_otau_plugin.so - STD OTAU Plugin
12:32:14:534 dev /dev/ttyAMA0
12:32:15:101 Announced to internet https://phoscon.de/discover
12:32:15:102 discovery server date: Sat, 14 Nov 2020 11:32:15 GMT
12:32:15:102 	 local time seems to be ok
12:32:15:103 discovery found version 2.04.35 for update channel stable
12:32:15:633 dev /dev/ttyAMA0
12:32:15:711 COM check bootloader
12:32:15:918 New websocket 172.30.32.1:39322 (state: 3) 
12:32:17:721 COM timout query bootloader, assume application
12:32:19:296 device state timeout ignored in state 2
12:32:33:816 start reconnect to network
12:32:34:316 device state timeout ignored in state 2
12:32:34:870 dev /dev/ttyAMA0
12:32:37:316 device state timeout ignored in state 2
12:32:38:816 try to reconnect to network try=1
12:32:43:316 device state timeout ignored in state 2
12:32:43:816 try to reconnect to network try=2
12:32:44:876 dev /dev/ttyAMA0
12:32:48:316 device state timeout ignored in state 2
12:32:48:816 try to reconnect to network try=3
12:32:53:315 device state timeout ignored in state 2
12:32:53:816 try to reconnect to network try=4
12:32:54:871 dev /dev/ttyAMA0
12:32:58:316 device state timeout ignored in state 2
12:32:58:816 try to reconnect to network try=5
12:33:03:316 device state timeout (handled)
12:33:03:322 device disconnected reason: 1, index: 0
12:33:03:816 failed to reconnect to network try=6
12:33:03:817 wait reconnect 15 seconds
12:33:04:816 void zmMaster::handleStateIdle(zmMaster::MasterEvent) not connected goto OFF state
12:33:04:817 device state timeout ignored in state 1
12:33:04:817 wait reconnect 14 seconds
12:33:04:870 dev /dev/ttyAMA0
12:33:05:816 wait reconnect 13 seconds
12:33:06:816 wait reconnect 12 seconds
12:33:07:815 wait reconnect 11 seconds
12:33:08:816 failed to reconnect to network try=7
12:33:08:816 wait reconnect 10 seconds
12:33:09:815 wait reconnect 9 seconds
12:33:10:816 wait reconnect 8 seconds
12:33:11:816 wait reconnect 7 seconds
12:33:12:816 wait reconnect 6 seconds
12:33:13:816 failed to reconnect to network try=8
12:33:13:817 wait reconnect 5 seconds
12:33:14:815 wait reconnect 4 seconds
12:33:14:870 dev /dev/ttyAMA0
12:33:15:816 wait reconnect 3 seconds
12:33:16:816 wait reconnect 2 seconds
12:33:17:816 wait reconnect 1 seconds
12:33:17:867 dev /dev/ttyAMA0
12:33:17:911 dev /dev/ttyAMA0
12:33:18:763 COM check bootloader
</details>

The issue can be worked around by downgrading to the deCONZ version (2.05.84) used by version 6.4.1 of the addon.
@pvizeli @frenck

Relevant issue: #1677 
